### PR TITLE
Migrating from master and slave terminology

### DIFF
--- a/Django-1.6.2/django/conf/global_settings.py
+++ b/Django-1.6.2/django/conf/global_settings.py
@@ -219,7 +219,7 @@ TEMPLATE_STRING_IF_INVALID = ''
 
 # Default email address to use for various automated correspondence from
 # the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+DEFAULT_FROM_EMAIL = 'webmain@localhost'
 
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.

--- a/Django-1.6.2/django/db/backends/sqlite3/introspection.py
+++ b/Django-1.6.2/django/db/backends/sqlite3/introspection.py
@@ -54,7 +54,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # Skip the sqlite_sequence system table used for autoincrement key
         # generation.
         cursor.execute("""
-            SELECT name FROM sqlite_master
+            SELECT name FROM sqlite_main
             WHERE type='table' AND NOT name='sqlite_sequence'
             ORDER BY name""")
         return [row[0] for row in cursor.fetchall()]
@@ -74,7 +74,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         relations = {}
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(')+1:results.rindex(')')]
 
@@ -92,7 +92,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
             table, column = [s.strip('"') for s in m.groups()]
 
-            cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s", [table])
+            cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s", [table])
             result = cursor.fetchall()[0]
             other_table_results = result[0].strip()
             li, ri = other_table_results.index('('), other_table_results.rindex(')')
@@ -119,7 +119,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         key_columns = []
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(')+1:results.rindex(')')]
 
@@ -164,7 +164,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         Get the column name of the primary key for the given table.
         """
         # Don't use PRAGMA because that causes issues with some transactions
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(')+1:results.rindex(')')]
         for field_desc in results.split(','):

--- a/Django-1.6.2/django/test/_doctest.py
+++ b/Django-1.6.2/django/test/_doctest.py
@@ -1528,7 +1528,7 @@ class DocTestRunner:
         return totalf, totalt
 
     #/////////////////////////////////////////////////////////////////
-    # Backward compatibility cruft to maintain doctest.master.
+    # Backward compatibility cruft to maintain doctest.main.
     #/////////////////////////////////////////////////////////////////
     def merge(self, other):
         d = self._name2ft
@@ -1822,7 +1822,7 @@ class DebugRunner(DocTestRunner):
 
 # For backward compatibility, a global instance of a DocTestRunner
 # class, updated by testmod.
-master = None
+main = None
 
 def testmod(m=None, name=None, globs=None, verbose=None,
             report=True, optionflags=0, extraglobs=None,
@@ -1884,13 +1884,13 @@ def testmod(m=None, name=None, globs=None, verbose=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     # If no module was given, then use __main__.
     if m is None:
@@ -1921,10 +1921,10 @@ def testmod(m=None, name=None, globs=None, verbose=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 
@@ -2002,13 +2002,13 @@ def testfile(filename, module_relative=True, name=None, package=None,
 
     Advanced tomfoolery:  testmod runs methods of a local instance of
     class doctest.Tester, then merges the results into (or creates)
-    global Tester instance doctest.master.  Methods of doctest.master
+    global Tester instance doctest.main.  Methods of doctest.main
     can be called directly too, if you want to do something unusual.
     Passing report=0 to testmod is especially useful then, to delay
-    displaying a summary.  Invoke doctest.master.summarize(verbose)
+    displaying a summary.  Invoke doctest.main.summarize(verbose)
     when you're done fiddling.
     """
-    global master
+    global main
 
     if package and not module_relative:
         raise ValueError("Package may only be specified for module-"
@@ -2044,10 +2044,10 @@ def testfile(filename, module_relative=True, name=None, package=None,
     if report:
         runner.summarize()
 
-    if master is None:
-        master = runner
+    if main is None:
+        main = runner
     else:
-        master.merge(runner)
+        main.merge(runner)
 
     return runner.failures, runner.tries
 

--- a/Django-1.6.2/django/test/client.py
+++ b/Django-1.6.2/django/test/client.py
@@ -406,7 +406,7 @@ class Client(RequestFactory):
 
     def request(self, **request):
         """
-        The master request method. Composes the environment dictionary
+        The main request method. Composes the environment dictionary
         and passes to the handler, returning the result of the handler.
         Assumes defaults for the query environment, which can be overridden
         using the arguments to the request.

--- a/Django-1.6.2/docs/conf.py
+++ b/Django-1.6.2/docs/conf.py
@@ -42,8 +42,8 @@ source_suffix = '.txt'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'contents'
+# The main toctree document.
+main_doc = 'contents'
 
 # General substitutions.
 project = 'Django'
@@ -265,7 +265,7 @@ man_pages = [
 # List of tuples (startdocname, targetname, title, author, dir_entry,
 # description, category, toctree_only)
 texinfo_documents=[(
-    master_doc, "django", "", "", "Django",
+    main_doc, "django", "", "", "Django",
     "Documentation of the Django framework", "Web development", False
 )]
 

--- a/Django-1.6.2/tests/multiple_database/tests.py
+++ b/Django-1.6.2/tests/multiple_database/tests.py
@@ -880,7 +880,7 @@ class QueryTestCase(TestCase):
         self.assertEqual(book.editor._state.db, 'other')
 
     def test_subquery(self):
-        """Make sure as_sql works with subqueries and master/slave."""
+        """Make sure as_sql works with subqueries and main/subordinate."""
         sub = Person.objects.using('other').filter(name='fff')
         qs = Book.objects.filter(editor__in=sub)
 
@@ -922,7 +922,7 @@ class QueryTestCase(TestCase):
 
 
 class TestRouter(object):
-    # A test router. The behavior is vaguely master/slave, but the
+    # A test router. The behavior is vaguely main/subordinate, but the
     # databases aren't assumed to propagate changes.
     def db_for_read(self, model, instance=None, **hints):
         if instance:
@@ -1003,7 +1003,7 @@ class RouterTestCase(TestCase):
     multi_db = True
 
     def setUp(self):
-        # Make the 'other' database appear to be a slave of the 'default'
+        # Make the 'other' database appear to be a subordinate of the 'default'
         self.old_routers = router.routers
         router.routers = [TestRouter()]
 
@@ -1159,7 +1159,7 @@ class RouterTestCase(TestCase):
         try:
             dive.editor = marty
         except ValueError:
-            self.fail("Assignment across master/slave databases with a common source should be ok")
+            self.fail("Assignment across main/subordinate databases with a common source should be ok")
 
         # Database assignments of original objects haven't changed...
         self.assertEqual(marty._state.db, 'default')
@@ -1177,7 +1177,7 @@ class RouterTestCase(TestCase):
         except Book.DoesNotExist:
             self.fail('Source database should have a copy of saved object')
 
-        # This isn't a real master-slave database, so restore the original from other
+        # This isn't a real main-subordinate database, so restore the original from other
         dive = Book.objects.using('other').get(title='Dive into Python')
         self.assertEqual(dive._state.db, 'other')
 
@@ -1185,7 +1185,7 @@ class RouterTestCase(TestCase):
         try:
             marty.edited = [pro, dive]
         except ValueError:
-            self.fail("Assignment across master/slave databases with a common source should be ok")
+            self.fail("Assignment across main/subordinate databases with a common source should be ok")
 
         # Assignment implies a save, so database assignments of original objects have changed...
         self.assertEqual(marty._state.db, 'default')
@@ -1199,7 +1199,7 @@ class RouterTestCase(TestCase):
         except Book.DoesNotExist:
             self.fail('Source database should have a copy of saved object')
 
-        # This isn't a real master-slave database, so restore the original from other
+        # This isn't a real main-subordinate database, so restore the original from other
         dive = Book.objects.using('other').get(title='Dive into Python')
         self.assertEqual(dive._state.db, 'other')
 
@@ -1207,7 +1207,7 @@ class RouterTestCase(TestCase):
         try:
             marty.edited.add(dive)
         except ValueError:
-            self.fail("Assignment across master/slave databases with a common source should be ok")
+            self.fail("Assignment across main/subordinate databases with a common source should be ok")
 
         # Add implies a save, so database assignments of original objects have changed...
         self.assertEqual(marty._state.db, 'default')
@@ -1221,7 +1221,7 @@ class RouterTestCase(TestCase):
         except Book.DoesNotExist:
             self.fail('Source database should have a copy of saved object')
 
-        # This isn't a real master-slave database, so restore the original from other
+        # This isn't a real main-subordinate database, so restore the original from other
         dive = Book.objects.using('other').get(title='Dive into Python')
 
         # If you assign a FK object when the base object hasn't
@@ -1284,7 +1284,7 @@ class RouterTestCase(TestCase):
         mark = Person.objects.using('default').create(pk=2, name="Mark Pilgrim")
 
         # Now save back onto the usual database.
-        # This simulates master/slave - the objects exist on both database,
+        # This simulates main/subordinate - the objects exist on both database,
         # but the _state.db is as it is for all other tests.
         pro.save(using='default')
         marty.save(using='default')
@@ -1301,7 +1301,7 @@ class RouterTestCase(TestCase):
         try:
             marty.book_set = [pro, dive]
         except ValueError:
-            self.fail("Assignment across master/slave databases with a common source should be ok")
+            self.fail("Assignment across main/subordinate databases with a common source should be ok")
 
         # Database assignments don't change
         self.assertEqual(marty._state.db, 'default')
@@ -1320,7 +1320,7 @@ class RouterTestCase(TestCase):
         try:
             marty.book_set.add(dive)
         except ValueError:
-            self.fail("Assignment across master/slave databases with a common source should be ok")
+            self.fail("Assignment across main/subordinate databases with a common source should be ok")
 
         # Database assignments don't change
         self.assertEqual(marty._state.db, 'default')
@@ -1339,7 +1339,7 @@ class RouterTestCase(TestCase):
         try:
             dive.authors = [mark, marty]
         except ValueError:
-            self.fail("Assignment across master/slave databases with a common source should be ok")
+            self.fail("Assignment across main/subordinate databases with a common source should be ok")
 
         # Database assignments don't change
         self.assertEqual(marty._state.db, 'default')
@@ -1361,7 +1361,7 @@ class RouterTestCase(TestCase):
         try:
             dive.authors.add(marty)
         except ValueError:
-            self.fail("Assignment across master/slave databases with a common source should be ok")
+            self.fail("Assignment across main/subordinate databases with a common source should be ok")
 
         # Database assignments don't change
         self.assertEqual(marty._state.db, 'default')
@@ -1399,7 +1399,7 @@ class RouterTestCase(TestCase):
         try:
             bob.userprofile = alice_profile
         except ValueError:
-            self.fail("Assignment across master/slave databases with a common source should be ok")
+            self.fail("Assignment across main/subordinate databases with a common source should be ok")
 
         # Database assignments of original objects haven't changed...
         self.assertEqual(alice._state.db, 'default')
@@ -1430,7 +1430,7 @@ class RouterTestCase(TestCase):
         try:
             review1.content_object = dive
         except ValueError:
-            self.fail("Assignment across master/slave databases with a common source should be ok")
+            self.fail("Assignment across main/subordinate databases with a common source should be ok")
 
         # Database assignments of original objects haven't changed...
         self.assertEqual(pro._state.db, 'default')
@@ -1449,7 +1449,7 @@ class RouterTestCase(TestCase):
         except Book.DoesNotExist:
             self.fail('Source database should have a copy of saved object')
 
-        # This isn't a real master-slave database, so restore the original from other
+        # This isn't a real main-subordinate database, so restore the original from other
         dive = Book.objects.using('other').get(title='Dive into Python')
         self.assertEqual(dive._state.db, 'other')
 
@@ -1457,7 +1457,7 @@ class RouterTestCase(TestCase):
         try:
             dive.reviews.add(review1)
         except ValueError:
-            self.fail("Assignment across master/slave databases with a common source should be ok")
+            self.fail("Assignment across main/subordinate databases with a common source should be ok")
 
         # Database assignments of original objects haven't changed...
         self.assertEqual(pro._state.db, 'default')
@@ -1534,7 +1534,7 @@ class RouterTestCase(TestCase):
         self.assertEqual(pro.reviews.db_manager('default').all().db, 'default')
 
     def test_subquery(self):
-        """Make sure as_sql works with subqueries and master/slave."""
+        """Make sure as_sql works with subqueries and main/subordinate."""
         # Create a book and author on the other database
 
         mark = Person.objects.using('other').create(name="Mark Pilgrim")
@@ -1572,7 +1572,7 @@ class AuthTestCase(TestCase):
     multi_db = True
 
     def setUp(self):
-        # Make the 'other' database appear to be a slave of the 'default'
+        # Make the 'other' database appear to be a subordinate of the 'default'
         self.old_routers = router.routers
         router.routers = [AuthRouter()]
 

--- a/amqp-1.0.6/docs/conf.py
+++ b/amqp-1.0.6/docs/conf.py
@@ -29,8 +29,8 @@ templates_path = ['.templates']
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'py-amqp'

--- a/billiard-2.7.3.19/Doc/conf.py
+++ b/billiard-2.7.3.19/Doc/conf.py
@@ -34,8 +34,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'multiprocessing'

--- a/billiard-2.7.3.19/pavement.py
+++ b/billiard-2.7.3.19/pavement.py
@@ -44,7 +44,7 @@ def ghdocs(options):
             cp -r %s/* .    && \
             git commit . -m 'Rendered documentation for Github Pages.' && \
             git push origin gh-pages && \
-            git checkout master" % builtdocs)
+            git checkout main" % builtdocs)
 
 
 @task

--- a/celery-3.0.12/docs/conf.py
+++ b/celery-3.0.12/docs/conf.py
@@ -45,8 +45,8 @@ templates_path = ['.templates']
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Celery'

--- a/django-celery-3.0.11/docs/conf.py
+++ b/django-celery-3.0.11/docs/conf.py
@@ -26,8 +26,8 @@ templates_path = ['.templates']
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'django-celery'

--- a/django-tastypie-0.11.0/docs/conf.py
+++ b/django-tastypie-0.11.0/docs/conf.py
@@ -33,8 +33,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'toc'
+# The main toctree document.
+main_doc = 'toc'
 
 # General information about the project.
 project = u'Tastypie'
@@ -198,7 +198,7 @@ latex_documents = [
 # List of tuples (startdocname, targetname, title, author, dir_entry,
 # description, category, toctree_only)
 texinfo_documents=[(
-    master_doc, "django-tastypie", "", "", "Tastypie",
+    main_doc, "django-tastypie", "", "", "Tastypie",
     "Documentation of the Tastypie framework", "Web development", False
 )]
 

--- a/django-tastypie-mongoengine-0.4.5/docs/conf.py
+++ b/django-tastypie-mongoengine-0.4.5/docs/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'django-tastypie-mongoengine'

--- a/kombu-2.5.4/docs/conf.py
+++ b/kombu-2.5.4/docs/conf.py
@@ -24,8 +24,8 @@ templates_path = ['.templates']
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Kombu'

--- a/kombu-2.5.4/kombu/connection.py
+++ b/kombu-2.5.4/kombu/connection.py
@@ -167,7 +167,7 @@ class Connection(object):
                 alt.extend(hostname.split(';'))
                 hostname = alt[0]
             if '+' in hostname[:hostname.index('://')]:
-                # e.g. sqla+mysql://root:masterkey@localhost/
+                # e.g. sqla+mysql://root:mainkey@localhost/
                 params['transport'], params['hostname'] = hostname.split('+')
                 self.uri_prefix = params['transport']
             else:

--- a/mongoengine-0.8.7/docs/conf.py
+++ b/mongoengine-0.8.7/docs/conf.py
@@ -33,8 +33,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'MongoEngine'

--- a/mongoengine-0.8.7/mongoengine/connection.py
+++ b/mongoengine-0.8.7/mongoengine/connection.py
@@ -19,7 +19,7 @@ _dbs = {}
 
 
 def register_connection(alias, name, host=None, port=None,
-                        is_slave=False, read_preference=False, slaves=None,
+                        is_subordinate=False, read_preference=False, subordinates=None,
                         username=None, password=None, **kwargs):
     """Add a connection.
 
@@ -28,12 +28,12 @@ def register_connection(alias, name, host=None, port=None,
     :param name: the name of the specific database to use
     :param host: the host name of the :program:`mongod` instance to connect to
     :param port: the port that the :program:`mongod` instance is running on
-    :param is_slave: whether the connection can act as a slave
+    :param is_subordinate: whether the connection can act as a subordinate
       ** Depreciated pymongo 2.0.1+
     :param read_preference: The read preference for the collection
        ** Added pymongo 2.1
-    :param slaves: a list of aliases of slave connections; each of these must
-        be a registered connection that has :attr:`is_slave` set to ``True``
+    :param subordinates: a list of aliases of subordinate connections; each of these must
+        be a registered connection that has :attr:`is_subordinate` set to ``True``
     :param username: username to authenticate with
     :param password: password to authenticate with
     :param kwargs: allow ad-hoc parameters to be passed into the pymongo driver
@@ -45,8 +45,8 @@ def register_connection(alias, name, host=None, port=None,
         'name': name,
         'host': host or 'localhost',
         'port': port or 27017,
-        'is_slave': is_slave,
-        'slaves': slaves or [],
+        'is_subordinate': is_subordinate,
+        'subordinates': subordinates or [],
         'username': username,
         'password': password,
         'read_preference': read_preference
@@ -95,17 +95,17 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
 
         if hasattr(pymongo, 'version_tuple'):  # Support for 2.1+
             conn_settings.pop('name', None)
-            conn_settings.pop('slaves', None)
-            conn_settings.pop('is_slave', None)
+            conn_settings.pop('subordinates', None)
+            conn_settings.pop('is_subordinate', None)
             conn_settings.pop('username', None)
             conn_settings.pop('password', None)
         else:
-            # Get all the slave connections
-            if 'slaves' in conn_settings:
-                slaves = []
-                for slave_alias in conn_settings['slaves']:
-                    slaves.append(get_connection(slave_alias))
-                conn_settings['slaves'] = slaves
+            # Get all the subordinate connections
+            if 'subordinates' in conn_settings:
+                subordinates = []
+                for subordinate_alias in conn_settings['subordinates']:
+                    subordinates.append(get_connection(subordinate_alias))
+                conn_settings['subordinates'] = subordinates
                 conn_settings.pop('read_preference', None)
 
         connection_class = MongoClient

--- a/mongoengine-0.8.7/mongoengine/queryset/base.py
+++ b/mongoengine-0.8.7/mongoengine/queryset/base.py
@@ -54,7 +54,7 @@ class BaseQuerySet(object):
         self._snapshot = False
         self._timeout = True
         self._class_check = True
-        self._slave_okay = False
+        self._subordinate_okay = False
         self._read_preference = None
         self._iter = False
         self._scalar = []
@@ -75,7 +75,7 @@ class BaseQuerySet(object):
         self._skip = None
         self._hint = -1  # Using -1 as None is a valid value for hint
 
-    def __call__(self, q_obj=None, class_check=True, slave_okay=False,
+    def __call__(self, q_obj=None, class_check=True, subordinate_okay=False,
                  read_preference=None, **query):
         """Filter the selected documents by calling the
         :class:`~mongoengine.queryset.QuerySet` with a query.
@@ -86,7 +86,7 @@ class BaseQuerySet(object):
             objects, only the last one will be used
         :param class_check: If set to False bypass class name check when
             querying collection
-        :param slave_okay: if True, allows this query to be run against a
+        :param subordinate_okay: if True, allows this query to be run against a
             replica secondary.
         :params read_preference: if set, overrides connection-level
             read_preference from `ReplicaSetConnection`.
@@ -539,7 +539,7 @@ class BaseQuerySet(object):
 
         copy_props = ('_mongo_query', '_initial_query', '_none', '_query_obj',
                       '_where_clause', '_loaded_fields', '_ordering', '_snapshot',
-                      '_timeout', '_class_check', '_slave_okay', '_read_preference',
+                      '_timeout', '_class_check', '_subordinate_okay', '_read_preference',
                       '_iter', '_scalar', '_as_pymongo', '_as_pymongo_coerce',
                       '_limit', '_skip', '_hint', '_auto_dereference')
 
@@ -771,13 +771,13 @@ class BaseQuerySet(object):
         queryset._timeout = enabled
         return queryset
 
-    def slave_okay(self, enabled):
-        """Enable or disable the slave_okay when querying.
+    def subordinate_okay(self, enabled):
+        """Enable or disable the subordinate_okay when querying.
 
-        :param enabled: whether or not the slave_okay is enabled
+        :param enabled: whether or not the subordinate_okay is enabled
         """
         queryset = self.clone()
-        queryset._slave_okay = enabled
+        queryset._subordinate_okay = enabled
         return queryset
 
     def read_preference(self, read_preference):
@@ -1170,7 +1170,7 @@ class BaseQuerySet(object):
         if self._read_preference is not None:
             cursor_args['read_preference'] = self._read_preference
         else:
-            cursor_args['slave_okay'] = self._slave_okay
+            cursor_args['subordinate_okay'] = self._subordinate_okay
         if self._loaded_fields:
             cursor_args['fields'] = self._loaded_fields.as_dict()
         return cursor_args

--- a/mongoengine-0.8.7/tests/queryset/queryset.py
+++ b/mongoengine-0.8.7/tests/queryset/queryset.py
@@ -787,8 +787,8 @@ class QuerySetTest(unittest.TestCase):
 
             self.assertEqual(q, 3)
 
-    def test_slave_okay(self):
-        """Ensures that a query can take slave_okay syntax
+    def test_subordinate_okay(self):
+        """Ensures that a query can take subordinate_okay syntax
         """
         person1 = self.Person(name="User A", age=20)
         person1.save()
@@ -796,7 +796,7 @@ class QuerySetTest(unittest.TestCase):
         person2.save()
 
         # Retrieve the first person from the database
-        person = self.Person.objects.slave_okay(True).first()
+        person = self.Person.objects.subordinate_okay(True).first()
         self.assertTrue(isinstance(person, self.Person))
         self.assertEqual(person.name, "User A")
         self.assertEqual(person.age, 20)
@@ -807,23 +807,23 @@ class QuerySetTest(unittest.TestCase):
         p = self.Person.objects
         # Check default
         self.assertEqual(p._cursor_args,
-                {'snapshot': False, 'slave_okay': False, 'timeout': True})
+                {'snapshot': False, 'subordinate_okay': False, 'timeout': True})
 
-        p = p.snapshot(False).slave_okay(False).timeout(False)
+        p = p.snapshot(False).subordinate_okay(False).timeout(False)
         self.assertEqual(p._cursor_args,
-                {'snapshot': False, 'slave_okay': False, 'timeout': False})
+                {'snapshot': False, 'subordinate_okay': False, 'timeout': False})
 
-        p = p.snapshot(True).slave_okay(False).timeout(False)
+        p = p.snapshot(True).subordinate_okay(False).timeout(False)
         self.assertEqual(p._cursor_args,
-                {'snapshot': True, 'slave_okay': False, 'timeout': False})
+                {'snapshot': True, 'subordinate_okay': False, 'timeout': False})
 
-        p = p.snapshot(True).slave_okay(True).timeout(False)
+        p = p.snapshot(True).subordinate_okay(True).timeout(False)
         self.assertEqual(p._cursor_args,
-                {'snapshot': True, 'slave_okay': True, 'timeout': False})
+                {'snapshot': True, 'subordinate_okay': True, 'timeout': False})
 
-        p = p.snapshot(True).slave_okay(True).timeout(True)
+        p = p.snapshot(True).subordinate_okay(True).timeout(True)
         self.assertEqual(p._cursor_args,
-                         {'snapshot': True, 'slave_okay': True, 'timeout': True})
+                         {'snapshot': True, 'subordinate_okay': True, 'timeout': True})
 
     def test_repeated_iteration(self):
         """Ensure that QuerySet rewinds itself one iteration finishes.

--- a/pymongo-2.7/doc/conf.py
+++ b/pymongo-2.7/doc/conf.py
@@ -22,8 +22,8 @@ templates_path = ['_templates']
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'PyMongo'

--- a/pymongo-2.7/pymongo/collection.py
+++ b/pymongo-2.7/pymongo/collection.py
@@ -86,7 +86,7 @@ class Collection(common.BaseObject):
         .. mongodoc:: collections
         """
         super(Collection, self).__init__(
-            slave_okay=database.slave_okay,
+            subordinate_okay=database.subordinate_okay,
             read_preference=database.read_preference,
             tag_sets=database.tag_sets,
             secondary_acceptable_latency_ms=(
@@ -773,7 +773,7 @@ class Collection(common.BaseObject):
           - `as_class` (optional): class to use for documents in the
             query result (default is
             :attr:`~pymongo.mongo_client.MongoClient.document_class`)
-          - `slave_okay` (optional): if True, allows this query to
+          - `subordinate_okay` (optional): if True, allows this query to
             be run against a replica secondary.
           - `await_data` (optional): if True, the server will block for
             some extra time before returning, waiting for more data to
@@ -854,8 +854,8 @@ class Collection(common.BaseObject):
         .. mongodoc:: find
         .. _localThreshold: http://docs.mongodb.org/manual/reference/mongos/#cmdoption-mongos--localThreshold
         """
-        if not 'slave_okay' in kwargs:
-            kwargs['slave_okay'] = self.slave_okay
+        if not 'subordinate_okay' in kwargs:
+            kwargs['subordinate_okay'] = self.subordinate_okay
         if not 'read_preference' in kwargs:
             kwargs['read_preference'] = self.read_preference
         if not 'tag_sets' in kwargs:
@@ -896,11 +896,11 @@ class Collection(common.BaseObject):
             # All documents have now been processed.
 
         With :class:`~pymongo.mongo_replica_set_client.MongoReplicaSetClient`
-        or :class:`~pymongo.master_slave_connection.MasterSlaveConnection`,
+        or :class:`~pymongo.main_subordinate_connection.MainSubordinateConnection`,
         if the `read_preference` attribute of this instance is not set to
         :attr:`pymongo.read_preferences.ReadPreference.PRIMARY` or the
-        (deprecated) `slave_okay` attribute of this instance is set to `True`
-        the command will be sent to a secondary or slave.
+        (deprecated) `subordinate_okay` attribute of this instance is set to `True`
+        the command will be sent to a secondary or subordinate.
 
         :Parameters:
           - `num_cursors`: the number of cursors to return
@@ -908,7 +908,7 @@ class Collection(common.BaseObject):
         .. note:: Requires server version **>= 2.5.5**.
 
         """
-        use_master = not self.slave_okay and not self.read_preference
+        use_main = not self.subordinate_okay and not self.read_preference
         compile_re = kwargs.get('compile_re', False)
 
         command_kwargs = {
@@ -917,8 +917,8 @@ class Collection(common.BaseObject):
             'tag_sets': self.tag_sets,
             'secondary_acceptable_latency_ms': (
                 self.secondary_acceptable_latency_ms),
-            'slave_okay': self.slave_okay,
-            '_use_master': use_master}
+            'subordinate_okay': self.subordinate_okay,
+            '_use_main': use_main}
         command_kwargs.update(kwargs)
 
         result, conn_id = self.__database._command(
@@ -1256,11 +1256,11 @@ class Collection(common.BaseObject):
         collection.
 
         With :class:`~pymongo.mongo_replica_set_client.MongoReplicaSetClient`
-        or :class:`~pymongo.master_slave_connection.MasterSlaveConnection`,
+        or :class:`~pymongo.main_subordinate_connection.MainSubordinateConnection`,
         if the `read_preference` attribute of this instance is not set to
         :attr:`pymongo.read_preferences.ReadPreference.PRIMARY` or the
-        (deprecated) `slave_okay` attribute of this instance is set to `True`
-        the `aggregate command`_ will be sent to a secondary or slave.
+        (deprecated) `subordinate_okay` attribute of this instance is set to `True`
+        the `aggregate command`_ will be sent to a secondary or subordinate.
 
         :Parameters:
           - `pipeline`: a single command or list of aggregation commands
@@ -1294,7 +1294,7 @@ class Collection(common.BaseObject):
         if isinstance(pipeline, dict):
             pipeline = [pipeline]
 
-        use_master = not self.slave_okay and not self.read_preference
+        use_main = not self.subordinate_okay and not self.read_preference
 
         command_kwargs = {
             'pipeline': pipeline,
@@ -1302,8 +1302,8 @@ class Collection(common.BaseObject):
             'tag_sets': self.tag_sets,
             'secondary_acceptable_latency_ms': (
                 self.secondary_acceptable_latency_ms),
-            'slave_okay': self.slave_okay,
-            '_use_master': use_master}
+            'subordinate_okay': self.subordinate_okay,
+            '_use_main': use_main}
 
         command_kwargs.update(kwargs)
         result, conn_id = self.__database._command(
@@ -1336,12 +1336,12 @@ class Collection(common.BaseObject):
             to group by.
 
         With :class:`~pymongo.mongo_replica_set_client.MongoReplicaSetClient`
-        or :class:`~pymongo.master_slave_connection.MasterSlaveConnection`,
+        or :class:`~pymongo.main_subordinate_connection.MainSubordinateConnection`,
         if the `read_preference` attribute of this instance is not set to
         :attr:`pymongo.read_preferences.ReadPreference.PRIMARY` or
         :attr:`pymongo.read_preferences.ReadPreference.PRIMARY_PREFERRED`, or
-        the (deprecated) `slave_okay` attribute of this instance is set to
-        `True`, the group command will be sent to a secondary or slave.
+        the (deprecated) `subordinate_okay` attribute of this instance is set to
+        `True`, the group command will be sent to a secondary or subordinate.
 
         :Parameters:
           - `key`: fields to group by (see above description)
@@ -1374,7 +1374,7 @@ class Collection(common.BaseObject):
         if finalize is not None:
             group["finalize"] = Code(finalize)
 
-        use_master = not self.slave_okay and not self.read_preference
+        use_main = not self.subordinate_okay and not self.read_preference
 
         return self.__database.command("group", group,
                                        uuid_subtype=self.uuid_subtype,
@@ -1382,8 +1382,8 @@ class Collection(common.BaseObject):
                                        tag_sets=self.tag_sets,
                                        secondary_acceptable_latency_ms=(
                                            self.secondary_acceptable_latency_ms),
-                                       slave_okay=self.slave_okay,
-                                       _use_master=use_master,
+                                       subordinate_okay=self.subordinate_okay,
+                                       _use_main=use_main,
                                        **kwargs)["retval"]
 
     def rename(self, new_name, **kwargs):
@@ -1484,9 +1484,9 @@ class Collection(common.BaseObject):
                             "%s or dict" % (basestring.__name__,))
 
         if isinstance(out, dict) and out.get('inline'):
-            must_use_master = False
+            must_use_main = False
         else:
-            must_use_master = True
+            must_use_main = True
 
         response = self.__database.command("mapreduce", self.__name,
                                            uuid_subtype=self.uuid_subtype,
@@ -1495,7 +1495,7 @@ class Collection(common.BaseObject):
                                            tag_sets=self.tag_sets,
                                            secondary_acceptable_latency_ms=(
                                                self.secondary_acceptable_latency_ms),
-                                           out=out, _use_master=must_use_master,
+                                           out=out, _use_main=must_use_main,
                                            **kwargs)
 
         if full_response or not response.get('result'):
@@ -1519,12 +1519,12 @@ class Collection(common.BaseObject):
         response from the server to the `map reduce command`_.
 
         With :class:`~pymongo.mongo_replica_set_client.MongoReplicaSetClient`
-        or :class:`~pymongo.master_slave_connection.MasterSlaveConnection`,
+        or :class:`~pymongo.main_subordinate_connection.MainSubordinateConnection`,
         if the `read_preference` attribute of this instance is not set to
         :attr:`pymongo.read_preferences.ReadPreference.PRIMARY` or
         :attr:`pymongo.read_preferences.ReadPreference.PRIMARY_PREFERRED`, or
-        the (deprecated) `slave_okay` attribute of this instance is set to
-        `True`, the inline map reduce will be run on a secondary or slave.
+        the (deprecated) `subordinate_okay` attribute of this instance is set to
+        `True`, the inline map reduce will be run on a secondary or subordinate.
 
         :Parameters:
           - `map`: map function (as a JavaScript string)
@@ -1542,7 +1542,7 @@ class Collection(common.BaseObject):
         .. versionadded:: 1.10
         """
 
-        use_master = not self.slave_okay and not self.read_preference
+        use_main = not self.subordinate_okay and not self.read_preference
 
         res = self.__database.command("mapreduce", self.__name,
                                       uuid_subtype=self.uuid_subtype,
@@ -1550,8 +1550,8 @@ class Collection(common.BaseObject):
                                       tag_sets=self.tag_sets,
                                       secondary_acceptable_latency_ms=(
                                           self.secondary_acceptable_latency_ms),
-                                      slave_okay=self.slave_okay,
-                                      _use_master=use_master,
+                                      subordinate_okay=self.subordinate_okay,
+                                      _use_main=use_main,
                                       map=map, reduce=reduce,
                                       out={"inline": 1}, **kwargs)
 

--- a/pymongo-2.7/pymongo/command_cursor.py
+++ b/pymongo-2.7/pymongo/command_cursor.py
@@ -112,7 +112,7 @@ class CommandCursor(object):
             self.__killed = True
             raise
         except AutoReconnect:
-            # Don't send kill cursors to another server after a "not master"
+            # Don't send kill cursors to another server after a "not main"
             # error. It's completely pointless.
             self.__killed = True
             client.disconnect()

--- a/pymongo-2.7/pymongo/common.py
+++ b/pymongo-2.7/pymongo/common.py
@@ -252,8 +252,8 @@ def validate_uuid_subtype(dummy, value):
 # readpreferencetags is an alias for tag_sets.
 VALIDATORS = {
     'replicaset': validate_basestring,
-    'slaveok': validate_boolean,
-    'slave_okay': validate_boolean,
+    'subordinateok': validate_boolean,
+    'subordinate_okay': validate_boolean,
     'safe': validate_boolean,
     'w': validate_int_or_basestring,
     'wtimeout': validate_integer,
@@ -342,7 +342,7 @@ class BaseObject(object):
 
     def __init__(self, **options):
 
-        self.__slave_okay = False
+        self.__subordinate_okay = False
         self.__read_pref = ReadPreference.PRIMARY
         self.__tag_sets = [{}]
         self.__secondary_acceptable_latency_ms = 15
@@ -385,8 +385,8 @@ class BaseObject(object):
     def __set_options(self, options):
         """Validates and sets all options passed to this object."""
         for option, value in options.iteritems():
-            if option in ('slave_okay', 'slaveok'):
-                self.__slave_okay = validate_boolean(option, value)
+            if option in ('subordinate_okay', 'subordinateok'):
+                self.__subordinate_okay = validate_boolean(option, value)
             elif option in ('read_preference', "readpreference"):
                 self.__read_pref = validate_read_preference(option, value)
             elif option in ('tag_sets', 'readpreferencetags'):
@@ -482,23 +482,23 @@ class BaseObject(object):
 
     write_concern = property(__get_write_concern, __set_write_concern)
 
-    def __get_slave_okay(self):
+    def __get_subordinate_okay(self):
         """DEPRECATED. Use :attr:`read_preference` instead.
 
         .. versionchanged:: 2.1
-           Deprecated slave_okay.
+           Deprecated subordinate_okay.
         .. versionadded:: 2.0
         """
-        return self.__slave_okay
+        return self.__subordinate_okay
 
-    def __set_slave_okay(self, value):
-        """Property setter for slave_okay"""
-        warnings.warn("slave_okay is deprecated. Please use "
+    def __set_subordinate_okay(self, value):
+        """Property setter for subordinate_okay"""
+        warnings.warn("subordinate_okay is deprecated. Please use "
                       "read_preference instead.", DeprecationWarning,
                       stacklevel=2)
-        self.__slave_okay = validate_boolean('slave_okay', value)
+        self.__subordinate_okay = validate_boolean('subordinate_okay', value)
 
-    slave_okay = property(__get_slave_okay, __set_slave_okay)
+    subordinate_okay = property(__get_subordinate_okay, __set_subordinate_okay)
 
     def __get_read_pref(self):
         """The read preference mode for this instance.

--- a/pymongo-2.7/pymongo/connection.py
+++ b/pymongo-2.7/pymongo/connection.py
@@ -17,8 +17,8 @@
 .. warning::
    **DEPRECATED:** Please use :mod:`~pymongo.mongo_client` instead.
 
-.. seealso:: Module :mod:`~pymongo.master_slave_connection` for
-   connecting to master-slave clusters, and
+.. seealso:: Module :mod:`~pymongo.main_subordinate_connection` for
+   connecting to main-subordinate clusters, and
    :doc:`/examples/high_availability` for an example of how to connect
    to a replica set, or specify a list of mongos instances for automatic
    failover.
@@ -149,7 +149,7 @@ class Connection(MongoClient):
             - either directly or via a mongos:**
           | (ignored by standalone mongod instances)
 
-          - `slave_okay` or `slaveOk` (deprecated): Use `read_preference`
+          - `subordinate_okay` or `subordinateOk` (deprecated): Use `read_preference`
             instead.
           - `replicaSet`: (string) The name of the replica-set to connect to.
             The driver will verify that the replica-set it connects to matches
@@ -159,7 +159,7 @@ class Connection(MongoClient):
           - `read_preference`: The read preference for this client. If
             connecting to a secondary then a read preference mode *other* than
             PRIMARY is required - otherwise all queries will throw a
-            :class:`~pymongo.errors.AutoReconnect` "not master" error.
+            :class:`~pymongo.errors.AutoReconnect` "not main" error.
             See :class:`~pymongo.read_preferences.ReadPreference` for all
             available read preference options.
           - `tag_sets`: Ignored unless connecting to a replica-set via mongos.
@@ -201,9 +201,9 @@ class Connection(MongoClient):
         .. versionchanged:: 2.1
            Support `w` = integer or string.
            Added `ssl` option.
-           DEPRECATED slave_okay/slaveOk.
+           DEPRECATED subordinate_okay/subordinateOk.
         .. versionchanged:: 2.0
-           `slave_okay` is a pure keyword argument. Added support for safe,
+           `subordinate_okay` is a pure keyword argument. Added support for safe,
            and getlasterror options as keyword arguments.
         .. versionchanged:: 1.11
            Added `max_pool_size`. Completely removed previously deprecated

--- a/pymongo-2.7/pymongo/cursor.py
+++ b/pymongo-2.7/pymongo/cursor.py
@@ -27,7 +27,7 @@ from pymongo.errors import (AutoReconnect,
 
 _QUERY_OPTIONS = {
     "tailable_cursor": 2,
-    "slave_okay": 4,
+    "subordinate_okay": 4,
     "oplog_replay": 8,
     "no_timeout": 16,
     "await_data": 32,
@@ -66,11 +66,11 @@ class Cursor(object):
 
     def __init__(self, collection, spec=None, fields=None, skip=0, limit=0,
                  timeout=True, snapshot=False, tailable=False, sort=None,
-                 max_scan=None, as_class=None, slave_okay=False,
+                 max_scan=None, as_class=None, subordinate_okay=False,
                  await_data=False, partial=False, manipulate=True,
                  read_preference=ReadPreference.PRIMARY,
                  tag_sets=[{}], secondary_acceptable_latency_ms=None,
-                 exhaust=False, compile_re=True, _must_use_master=False,
+                 exhaust=False, compile_re=True, _must_use_main=False,
                  _uuid_subtype=None, **kwargs):
         """Create a new cursor.
 
@@ -96,8 +96,8 @@ class Cursor(object):
             raise TypeError("snapshot must be an instance of bool")
         if not isinstance(tailable, bool):
             raise TypeError("tailable must be an instance of bool")
-        if not isinstance(slave_okay, bool):
-            raise TypeError("slave_okay must be an instance of bool")
+        if not isinstance(subordinate_okay, bool):
+            raise TypeError("subordinate_okay must be an instance of bool")
         if not isinstance(await_data, bool):
             raise TypeError("await_data must be an instance of bool")
         if not isinstance(partial, bool):
@@ -148,14 +148,14 @@ class Cursor(object):
         self.__hint = None
         self.__comment = None
         self.__as_class = as_class
-        self.__slave_okay = slave_okay
+        self.__subordinate_okay = subordinate_okay
         self.__manipulate = manipulate
         self.__read_preference = read_preference
         self.__tag_sets = tag_sets
         self.__secondary_acceptable_latency_ms = secondary_acceptable_latency_ms
         self.__tz_aware = collection.database.connection.tz_aware
         self.__compile_re = compile_re
-        self.__must_use_master = _must_use_master
+        self.__must_use_main = _must_use_main
         self.__uuid_subtype = _uuid_subtype or collection.uuid_subtype
 
         self.__data = deque()
@@ -240,10 +240,10 @@ class Cursor(object):
         values_to_clone = ("spec", "fields", "skip", "limit", "max_time_ms",
                            "comment", "max", "min",
                            "snapshot", "ordering", "explain", "hint",
-                           "batch_size", "max_scan", "as_class", "slave_okay",
+                           "batch_size", "max_scan", "as_class", "subordinate_okay",
                            "manipulate", "read_preference", "tag_sets",
                            "secondary_acceptable_latency_ms",
-                           "must_use_master", "uuid_subtype", "compile_re",
+                           "must_use_main", "uuid_subtype", "compile_re",
                            "query_flags", "kwargs")
         data = dict((k, v) for k, v in self.__dict__.iteritems()
                     if k.startswith('_Cursor__') and k[9:] in values_to_clone)
@@ -315,7 +315,7 @@ class Cursor(object):
 
             # For maximum backwards compatibility, don't set $readPreference
             # for SECONDARY_PREFERRED unless tags are in use. Just rely on
-            # the slaveOkay bit (set automatically if read preference is not
+            # the subordinateOkay bit (set automatically if read preference is not
             # PRIMARY), which has the same behavior.
             if (self.__read_preference != ReadPreference.SECONDARY_PREFERRED or
                 has_tags):
@@ -373,10 +373,10 @@ class Cursor(object):
         """Get the query options string to use for this query.
         """
         options = self.__query_flags
-        if (self.__slave_okay
+        if (self.__subordinate_okay
             or self.__read_preference != ReadPreference.PRIMARY
         ):
-            options |= _QUERY_OPTIONS["slave_okay"]
+            options |= _QUERY_OPTIONS["subordinate_okay"]
         return options
 
     def __check_okay_to_chain(self):
@@ -395,8 +395,8 @@ class Cursor(object):
             raise TypeError("mask must be an int")
         self.__check_okay_to_chain()
 
-        if mask & _QUERY_OPTIONS["slave_okay"]:
-            self.__slave_okay = True
+        if mask & _QUERY_OPTIONS["subordinate_okay"]:
+            self.__subordinate_okay = True
         if mask & _QUERY_OPTIONS["exhaust"]:
             if self.__limit:
                 raise InvalidOperation("Can't use limit and exhaust together.")
@@ -418,8 +418,8 @@ class Cursor(object):
             raise TypeError("mask must be an int")
         self.__check_okay_to_chain()
 
-        if mask & _QUERY_OPTIONS["slave_okay"]:
-            self.__slave_okay = False
+        if mask & _QUERY_OPTIONS["subordinate_okay"]:
+            self.__subordinate_okay = False
         if mask & _QUERY_OPTIONS["exhaust"]:
             self.__exhaust = False
 
@@ -692,12 +692,12 @@ class Cursor(object):
         Raises :class:`~pymongo.errors.OperationFailure` on a database error.
 
         With :class:`~pymongo.mongo_replica_set_client.MongoReplicaSetClient`
-        or :class:`~pymongo.master_slave_connection.MasterSlaveConnection`,
+        or :class:`~pymongo.main_subordinate_connection.MainSubordinateConnection`,
         if `read_preference` is not
         :attr:`pymongo.read_preferences.ReadPreference.PRIMARY` or
         :attr:`pymongo.read_preferences.ReadPreference.PRIMARY_PREFERRED`, or
-        (deprecated) `slave_okay` is `True`, the count command will be sent to
-        a secondary or slave.
+        (deprecated) `subordinate_okay` is `True`, the count command will be sent to
+        a secondary or subordinate.
 
         :Parameters:
           - `with_limit_and_skip` (optional): take any :meth:`limit` or
@@ -725,9 +725,9 @@ class Cursor(object):
         command['tag_sets'] = self.__tag_sets
         command['secondary_acceptable_latency_ms'] = (
             self.__secondary_acceptable_latency_ms)
-        command['slave_okay'] = self.__slave_okay
-        use_master = not self.__slave_okay and not self.__read_preference
-        command['_use_master'] = use_master
+        command['subordinate_okay'] = self.__subordinate_okay
+        use_main = not self.__subordinate_okay and not self.__read_preference
+        command['_use_main'] = use_main
         if self.__max_time_ms is not None:
             command["maxTimeMS"] = self.__max_time_ms
         if self.__comment:
@@ -757,11 +757,11 @@ class Cursor(object):
         :class:`basestring` (:class:`str` in python 3).
 
         With :class:`~pymongo.mongo_replica_set_client.MongoReplicaSetClient`
-        or :class:`~pymongo.master_slave_connection.MasterSlaveConnection`,
+        or :class:`~pymongo.main_subordinate_connection.MainSubordinateConnection`,
         if `read_preference` is
         not :attr:`pymongo.read_preferences.ReadPreference.PRIMARY` or
-        (deprecated) `slave_okay` is `True` the distinct command will be sent
-        to a secondary or slave.
+        (deprecated) `subordinate_okay` is `True` the distinct command will be sent
+        to a secondary or subordinate.
 
         :Parameters:
           - `key`: name of key for which we want to get the distinct values
@@ -784,9 +784,9 @@ class Cursor(object):
         options['tag_sets'] = self.__tag_sets
         options['secondary_acceptable_latency_ms'] = (
             self.__secondary_acceptable_latency_ms)
-        options['slave_okay'] = self.__slave_okay
-        use_master = not self.__slave_okay and not self.__read_preference
-        options['_use_master'] = use_master
+        options['subordinate_okay'] = self.__subordinate_okay
+        use_main = not self.__subordinate_okay and not self.__read_preference
+        options['_use_main'] = use_main
         if self.__max_time_ms is not None:
             options['maxTimeMS'] = self.__max_time_ms
         if self.__comment:
@@ -892,7 +892,7 @@ class Cursor(object):
         client = self.__collection.database.connection
 
         if message:
-            kwargs = {"_must_use_master": self.__must_use_master}
+            kwargs = {"_must_use_main": self.__must_use_main}
             kwargs["read_preference"] = self.__read_preference
             kwargs["tag_sets"] = self.__tag_sets
             kwargs["secondary_acceptable_latency_ms"] = (
@@ -933,7 +933,7 @@ class Cursor(object):
                 return
             raise
         except AutoReconnect:
-            # Don't send kill cursors to another server after a "not master"
+            # Don't send kill cursors to another server after a "not main"
             # error. It's completely pointless.
             self.__killed = True
             client.disconnect()

--- a/pymongo-2.7/pymongo/database.py
+++ b/pymongo-2.7/pymongo/database.py
@@ -60,7 +60,7 @@ class Database(common.BaseObject):
         .. mongodoc:: databases
         """
         super(Database,
-              self).__init__(slave_okay=connection.slave_okay,
+              self).__init__(subordinate_okay=connection.subordinate_okay,
                              read_preference=connection.read_preference,
                              tag_sets=connection.tag_sets,
                              secondary_acceptable_latency_ms=(
@@ -281,27 +281,27 @@ class Database(common.BaseObject):
             command = SON([(command, value)])
 
         command_name = command.keys()[0].lower()
-        must_use_master = kwargs.pop('_use_master', False)
+        must_use_main = kwargs.pop('_use_main', False)
         if command_name not in rp.secondary_ok_commands:
-            must_use_master = True
+            must_use_main = True
 
         # Special-case: mapreduce can go to secondaries only if inline
         if command_name == 'mapreduce':
             out = command.get('out') or kwargs.get('out')
             if not isinstance(out, dict) or not out.get('inline'):
-                must_use_master = True
+                must_use_main = True
 
         # Special-case: aggregate with $out cannot go to secondaries.
         if command_name == 'aggregate':
             for stage in kwargs.get('pipeline', []):
                 if '$out' in stage:
-                    must_use_master = True
+                    must_use_main = True
                     break
 
         extra_opts = {
             'as_class': kwargs.pop('as_class', None),
-            'slave_okay': kwargs.pop('slave_okay', self.slave_okay),
-            '_must_use_master': must_use_master,
+            'subordinate_okay': kwargs.pop('subordinate_okay', self.subordinate_okay),
+            '_must_use_main': must_use_main,
             '_uuid_subtype': uuid_subtype
         }
 
@@ -322,9 +322,9 @@ class Database(common.BaseObject):
 
         command.update(kwargs)
 
-        # Warn if must_use_master will override read_preference.
+        # Warn if must_use_main will override read_preference.
         if (extra_opts['read_preference'] != rp.ReadPreference.PRIMARY and
-                extra_opts['_must_use_master']):
+                extra_opts['_must_use_main']):
             warnings.warn("%s does not support %s read preference "
                           "and will be routed to the primary instead." %
                           (command_name,
@@ -441,7 +441,7 @@ class Database(common.BaseObject):
           - `include_system_collections` (optional): if ``False`` list
             will not include system collections (e.g ``system.indexes``)
         """
-        results = self["system.namespaces"].find(_must_use_master=True)
+        results = self["system.namespaces"].find(_must_use_main=True)
         names = [r["name"] for r in results]
         names = [n[len(self.__name) + 1:] for n in names
                  if n.startswith(self.__name + ".") and "$" not in n]
@@ -614,7 +614,7 @@ class Database(common.BaseObject):
         error_msg = error.get("err", "")
         if error_msg is None:
             return None
-        if error_msg.startswith("not master"):
+        if error_msg.startswith("not main"):
             self.__connection.disconnect()
         return error
 

--- a/pymongo-2.7/pymongo/helpers.py
+++ b/pymongo-2.7/pymongo/helpers.py
@@ -97,7 +97,7 @@ def _unpack_response(response, cursor_id=None, as_class=dict,
                              cursor_id)
     elif response_flag & 2:
         error_object = bson.BSON(response[20:]).decode()
-        if error_object["$err"].startswith("not master"):
+        if error_object["$err"].startswith("not main"):
             raise AutoReconnect(error_object["$err"])
         elif error_object.get("code") == 50:
             raise ExecutionTimeout(error_object.get("$err"),
@@ -151,8 +151,8 @@ def _check_command_response(response, reset, msg=None, allowable_errors=None):
         errmsg = details["errmsg"]
         if allowable_errors is None or errmsg not in allowable_errors:
 
-            # Server is "not master" or "recovering"
-            if (errmsg.startswith("not master")
+            # Server is "not main" or "recovering"
+            if (errmsg.startswith("not main")
                 or errmsg.startswith("node is recovering")):
                 if reset is not None:
                     reset()

--- a/pymongo-2.7/pymongo/master_slave_connection.py
+++ b/pymongo-2.7/pymongo/master_slave_connection.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Master-Slave connection to Mongo.
+"""Main-Subordinate connection to Mongo.
 
-Performs all writes to Master instance and distributes reads among all
-slaves. Reads are tried on each slave in turn until the read succeeds
-or all slaves failed.
+Performs all writes to Main instance and distributes reads among all
+subordinates. Reads are tried on each subordinate in turn until the read succeeds
+or all subordinates failed.
 """
 
 from pymongo import helpers, thread_util
@@ -27,68 +27,68 @@ from pymongo.database import Database
 from pymongo.errors import AutoReconnect
 
 
-class MasterSlaveConnection(BaseObject):
-    """A master-slave connection to Mongo.
+class MainSubordinateConnection(BaseObject):
+    """A main-subordinate connection to Mongo.
     """
 
-    def __init__(self, master, slaves=[], document_class=dict, tz_aware=False):
-        """Create a new Master-Slave connection.
+    def __init__(self, main, subordinates=[], document_class=dict, tz_aware=False):
+        """Create a new Main-Subordinate connection.
 
         The resultant connection should be interacted with using the same
         mechanisms as a regular `MongoClient`. The `MongoClient` instances used
-        to create this `MasterSlaveConnection` can themselves make use of
-        connection pooling, etc. `MongoClient` instances used as slaves should
+        to create this `MainSubordinateConnection` can themselves make use of
+        connection pooling, etc. `MongoClient` instances used as subordinates should
         be created with the read_preference option set to
         :attr:`~pymongo.read_preferences.ReadPreference.SECONDARY`. Write
-        concerns are inherited from `master` and can be changed in this
+        concerns are inherited from `main` and can be changed in this
         instance.
 
-        Raises TypeError if `master` is not an instance of `MongoClient` or
-        slaves is not a list of at least one `MongoClient` instances.
+        Raises TypeError if `main` is not an instance of `MongoClient` or
+        subordinates is not a list of at least one `MongoClient` instances.
 
         :Parameters:
-          - `master`: `MongoClient` instance for the writable Master
-          - `slaves`: list of `MongoClient` instances for the
-            read-only slaves
+          - `main`: `MongoClient` instance for the writable Main
+          - `subordinates`: list of `MongoClient` instances for the
+            read-only subordinates
           - `document_class` (optional): default class to use for
             documents returned from queries on this connection
           - `tz_aware` (optional): if ``True``,
             :class:`~datetime.datetime` instances returned as values
-            in a document by this :class:`MasterSlaveConnection` will be timezone
+            in a document by this :class:`MainSubordinateConnection` will be timezone
             aware (otherwise they will be naive)
         """
-        if not isinstance(master, MongoClient):
-            raise TypeError("master must be a MongoClient instance")
-        if not isinstance(slaves, list) or len(slaves) == 0:
-            raise TypeError("slaves must be a list of length >= 1")
+        if not isinstance(main, MongoClient):
+            raise TypeError("main must be a MongoClient instance")
+        if not isinstance(subordinates, list) or len(subordinates) == 0:
+            raise TypeError("subordinates must be a list of length >= 1")
 
-        for slave in slaves:
-            if not isinstance(slave, MongoClient):
-                raise TypeError("slave %r is not an instance of MongoClient" %
-                                slave)
+        for subordinate in subordinates:
+            if not isinstance(subordinate, MongoClient):
+                raise TypeError("subordinate %r is not an instance of MongoClient" %
+                                subordinate)
 
-        super(MasterSlaveConnection,
+        super(MainSubordinateConnection,
               self).__init__(read_preference=ReadPreference.SECONDARY,
-                             safe=master.safe,
-                             **master.write_concern)
+                             safe=main.safe,
+                             **main.write_concern)
 
-        self.__master = master
-        self.__slaves = slaves
+        self.__main = main
+        self.__subordinates = subordinates
         self.__document_class = document_class
         self.__tz_aware = tz_aware
-        self.__request_counter = thread_util.Counter(master.use_greenlets)
+        self.__request_counter = thread_util.Counter(main.use_greenlets)
 
     @property
-    def master(self):
-        return self.__master
+    def main(self):
+        return self.__main
 
     @property
-    def slaves(self):
-        return self.__slaves
+    def subordinates(self):
+        return self.__subordinates
 
     @property
     def is_mongos(self):
-        """If this MasterSlaveConnection is connected to mongos (always False)
+        """If this MainSubordinateConnection is connected to mongos (always False)
 
         .. versionadded:: 2.3
         """
@@ -101,7 +101,7 @@ class MasterSlaveConnection(BaseObject):
 
         .. versionadded:: 2.4.2
         """
-        return self.master.use_greenlets
+        return self.main.use_greenlets
 
     def get_document_class(self):
         return self.__document_class
@@ -119,21 +119,21 @@ class MasterSlaveConnection(BaseObject):
 
     @property
     def max_bson_size(self):
-        """Return the maximum size BSON object the connected master
+        """Return the maximum size BSON object the connected main
         accepts in bytes. Defaults to 4MB in server < 1.7.4.
 
         .. versionadded:: 2.6
         """
-        return self.master.max_bson_size
+        return self.main.max_bson_size
 
     @property
     def max_message_size(self):
-        """Return the maximum message size the connected master
+        """Return the maximum message size the connected main
         accepts in bytes.
 
         .. versionadded:: 2.6
         """
-        return self.master.max_message_size
+        return self.main.max_message_size
 
     @property
     def min_wire_version(self):
@@ -143,7 +143,7 @@ class MasterSlaveConnection(BaseObject):
 
         .. versionadded:: 2.7
         """
-        return self.master.min_wire_version
+        return self.main.min_wire_version
 
     @property
     def max_wire_version(self):
@@ -153,7 +153,7 @@ class MasterSlaveConnection(BaseObject):
 
         .. versionadded:: 2.7
         """
-        return self.master.max_wire_version
+        return self.main.max_wire_version
 
     @property
     def max_write_batch_size(self):
@@ -164,35 +164,35 @@ class MasterSlaveConnection(BaseObject):
 
         .. versionadded:: 2.7
         """
-        return self.master.max_write_batch_size
+        return self.main.max_write_batch_size
 
     def disconnect(self):
         """Disconnect from MongoDB.
 
-        Disconnecting will call disconnect on all master and slave
+        Disconnecting will call disconnect on all main and subordinate
         connections.
 
         .. seealso:: Module :mod:`~pymongo.mongo_client`
         .. versionadded:: 1.10.1
         """
-        self.__master.disconnect()
-        for slave in self.__slaves:
-            slave.disconnect()
+        self.__main.disconnect()
+        for subordinate in self.__subordinates:
+            subordinate.disconnect()
 
     def set_cursor_manager(self, manager_class):
         """Set the cursor manager for this connection.
 
         Helper to set cursor manager for each individual `MongoClient` instance
-        that make up this `MasterSlaveConnection`.
+        that make up this `MainSubordinateConnection`.
         """
-        self.__master.set_cursor_manager(manager_class)
-        for slave in self.__slaves:
-            slave.set_cursor_manager(manager_class)
+        self.__main.set_cursor_manager(manager_class)
+        for subordinate in self.__subordinates:
+            subordinate.set_cursor_manager(manager_class)
 
     def _ensure_connected(self, sync):
-        """Ensure the master is connected to a mongod/s.
+        """Ensure the main is connected to a mongod/s.
         """
-        self.__master._ensure_connected(sync)
+        self.__main._ensure_connected(sync)
 
     # _connection_to_use is a hack that we need to include to make sure
     # that killcursor operations can be sent to the same instance on which
@@ -202,7 +202,7 @@ class MasterSlaveConnection(BaseObject):
                       command=False, _connection_to_use=None):
         """Say something to Mongo.
 
-        Sends a message on the Master connection. This is used for inserts,
+        Sends a message on the Main connection. This is used for inserts,
         updates, and deletes.
 
         Raises ConnectionFailure if the message cannot be sent. Returns the
@@ -214,16 +214,16 @@ class MasterSlaveConnection(BaseObject):
           - `safe`: perform a getLastError after sending the message
         """
         if _connection_to_use is None or _connection_to_use == -1:
-            return self.__master._send_message(message,
+            return self.__main._send_message(message,
                                                with_last_error, command)
-        return self.__slaves[_connection_to_use]._send_message(
+        return self.__subordinates[_connection_to_use]._send_message(
             message, with_last_error, command, check_primary=False)
 
     # _connection_to_use is a hack that we need to include to make sure
     # that getmore operations can be sent to the same instance on which
     # the cursor actually resides...
     def _send_message_with_response(self, message, _connection_to_use=None,
-                                    _must_use_master=False, **kwargs):
+                                    _must_use_main=False, **kwargs):
         """Receive a message from Mongo.
 
         Sends the given message and returns a (connection_id, response) pair.
@@ -234,43 +234,43 @@ class MasterSlaveConnection(BaseObject):
         """
         if _connection_to_use is not None:
             if _connection_to_use == -1:
-                member = self.__master
+                member = self.__main
                 conn = -1
             else:
-                member = self.__slaves[_connection_to_use]
+                member = self.__subordinates[_connection_to_use]
                 conn = _connection_to_use
             return (conn,
                     member._send_message_with_response(message, **kwargs)[1])
 
-        # _must_use_master is set for commands, which must be sent to the
-        # master instance. any queries in a request must be sent to the
-        # master since that is where writes go.
-        if _must_use_master or self.in_request():
-            return (-1, self.__master._send_message_with_response(message,
+        # _must_use_main is set for commands, which must be sent to the
+        # main instance. any queries in a request must be sent to the
+        # main since that is where writes go.
+        if _must_use_main or self.in_request():
+            return (-1, self.__main._send_message_with_response(message,
                                                                   **kwargs)[1])
 
-        # Iterate through the slaves randomly until we have success. Raise
+        # Iterate through the subordinates randomly until we have success. Raise
         # reconnect if they all fail.
-        for connection_id in helpers.shuffled(xrange(len(self.__slaves))):
+        for connection_id in helpers.shuffled(xrange(len(self.__subordinates))):
             try:
-                slave = self.__slaves[connection_id]
+                subordinate = self.__subordinates[connection_id]
                 return (connection_id,
-                        slave._send_message_with_response(message,
+                        subordinate._send_message_with_response(message,
                                                           **kwargs)[1])
             except AutoReconnect:
                 pass
 
-        raise AutoReconnect("failed to connect to slaves")
+        raise AutoReconnect("failed to connect to subordinates")
 
     def start_request(self):
         """Start a "request".
 
         Start a sequence of operations in which order matters. Note
         that all operations performed within a request will be sent
-        using the Master connection.
+        using the Main connection.
         """
         self.__request_counter.inc()
-        self.master.start_request()
+        self.main.start_request()
 
     def in_request(self):
         return bool(self.__request_counter.get())
@@ -281,12 +281,12 @@ class MasterSlaveConnection(BaseObject):
         See documentation for `MongoClient.end_request`.
         """
         self.__request_counter.dec()
-        self.master.end_request()
+        self.main.end_request()
 
     def __eq__(self, other):
-        if isinstance(other, MasterSlaveConnection):
-            us = (self.__master, self.slaves)
-            them = (other.__master, other.__slaves)
+        if isinstance(other, MainSubordinateConnection):
+            us = (self.__main, self.subordinates)
+            them = (other.__main, other.__subordinates)
             return us == them
         return NotImplemented
 
@@ -294,7 +294,7 @@ class MasterSlaveConnection(BaseObject):
         return not self == other
 
     def __repr__(self):
-        return "MasterSlaveConnection(%r, %r)" % (self.__master, self.__slaves)
+        return "MainSubordinateConnection(%r, %r)" % (self.__main, self.__subordinates)
 
     def __getattr__(self, name):
         """Get a database by name.
@@ -329,13 +329,13 @@ class MasterSlaveConnection(BaseObject):
             was opened
         """
         if connection_id == -1:
-            return self.__master.close_cursor(cursor_id)
-        return self.__slaves[connection_id].close_cursor(cursor_id)
+            return self.__main.close_cursor(cursor_id)
+        return self.__subordinates[connection_id].close_cursor(cursor_id)
 
     def database_names(self):
         """Get a list of all database names.
         """
-        return self.__master.database_names()
+        return self.__main.database_names()
 
     def drop_database(self, name_or_database):
         """Drop a database.
@@ -344,25 +344,25 @@ class MasterSlaveConnection(BaseObject):
           - `name_or_database`: the name of a database to drop or the object
             itself
         """
-        return self.__master.drop_database(name_or_database)
+        return self.__main.drop_database(name_or_database)
 
     def __iter__(self):
         return self
 
     def next(self):
-        raise TypeError("'MasterSlaveConnection' object is not iterable")
+        raise TypeError("'MainSubordinateConnection' object is not iterable")
 
     def _cached(self, database_name, collection_name, index_name):
-        return self.__master._cached(database_name,
+        return self.__main._cached(database_name,
                                      collection_name, index_name)
 
     def _cache_index(self, database_name, collection_name,
                      index_name, cache_for):
-        return self.__master._cache_index(database_name, collection_name,
+        return self.__main._cache_index(database_name, collection_name,
                                           index_name, cache_for)
 
     def _purge_index(self, database_name,
                      collection_name=None, index_name=None):
-        return self.__master._purge_index(database_name,
+        return self.__main._purge_index(database_name,
                                           collection_name,
                                           index_name)

--- a/pymongo-2.7/pymongo/member.py
+++ b/pymongo-2.7/pymongo/member.py
@@ -32,39 +32,39 @@ class Member(object):
     :Parameters:
       - `host`: A (host, port) pair
       - `connection_pool`: A Pool instance
-      - `ismaster_response`: A dict, MongoDB's ismaster response
+      - `ismain_response`: A dict, MongoDB's ismain response
       - `ping_time`: A MovingAverage instance
     """
     # For unittesting only. Use under no circumstances!
     _host_to_ping_time = {}
 
-    def __init__(self, host, connection_pool, ismaster_response, ping_time):
+    def __init__(self, host, connection_pool, ismain_response, ping_time):
         self.host = host
         self.pool = connection_pool
-        self.ismaster_response = ismaster_response
+        self.ismain_response = ismain_response
         self.ping_time = ping_time
-        self.is_mongos = (ismaster_response.get('msg') == 'isdbgrid')
+        self.is_mongos = (ismain_response.get('msg') == 'isdbgrid')
 
-        if ismaster_response['ismaster']:
+        if ismain_response['ismain']:
             self.state = PRIMARY
-        elif ismaster_response.get('secondary'):
+        elif ismain_response.get('secondary'):
             self.state = SECONDARY
-        elif ismaster_response.get('arbiterOnly'):
+        elif ismain_response.get('arbiterOnly'):
             self.state = ARBITER
         else:
             self.state = OTHER
 
-        self.set_name = ismaster_response.get('setName')
-        self.tags = ismaster_response.get('tags', {})
-        self.max_bson_size = ismaster_response.get(
+        self.set_name = ismain_response.get('setName')
+        self.tags = ismain_response.get('tags', {})
+        self.max_bson_size = ismain_response.get(
             'maxBsonObjectSize', common.MAX_BSON_SIZE)
-        self.max_message_size = ismaster_response.get(
+        self.max_message_size = ismain_response.get(
             'maxMessageSizeBytes', 2 * self.max_bson_size)
-        self.min_wire_version = ismaster_response.get(
+        self.min_wire_version = ismain_response.get(
             'minWireVersion', common.MIN_WIRE_VERSION)
-        self.max_wire_version = ismaster_response.get(
+        self.max_wire_version = ismain_response.get(
             'maxWireVersion', common.MAX_WIRE_VERSION)
-        self.max_write_batch_size = ismaster_response.get(
+        self.max_write_batch_size = ismain_response.get(
             'maxWriteBatchSize', common.MAX_WRITE_BATCH_SIZE)
 
         # self.min/max_wire_version is the server's wire protocol.
@@ -83,11 +83,11 @@ class Member(object):
                    common.MIN_SUPPORTED_WIRE_VERSION,
                    common.MAX_SUPPORTED_WIRE_VERSION))
 
-    def clone_with(self, ismaster_response, ping_time_sample):
-        """Get a clone updated with ismaster response and a single ping time.
+    def clone_with(self, ismain_response, ping_time_sample):
+        """Get a clone updated with ismain response and a single ping time.
         """
         ping_time = self.ping_time.clone_with(ping_time_sample)
-        return Member(self.host, self.pool, ismaster_response, ping_time)
+        return Member(self.host, self.pool, ismain_response, ping_time)
 
     @property
     def is_primary(self):

--- a/pymongo-2.7/pymongo/mongo_client.py
+++ b/pymongo-2.7/pymongo/mongo_client.py
@@ -14,8 +14,8 @@
 
 """Tools for connecting to MongoDB.
 
-.. seealso:: Module :mod:`~pymongo.master_slave_connection` for
-   connecting to master-slave clusters, and
+.. seealso:: Module :mod:`~pymongo.main_subordinate_connection` for
+   connecting to main-subordinate clusters, and
    :doc:`/examples/high_availability` for an example of how to connect
    to a replica set, or specify a list of mongos instances for automatic
    failover.
@@ -190,7 +190,7 @@ class MongoClient(common.BaseObject):
           - `read_preference`: The read preference for this client. If
             connecting to a secondary then a read preference mode *other* than
             PRIMARY is required - otherwise all queries will throw
-            :class:`~pymongo.errors.AutoReconnect` "not master".
+            :class:`~pymongo.errors.AutoReconnect` "not main".
             See :class:`~pymongo.read_preferences.ReadPreference` for all
             available read preference options.
           - `tag_sets`: Ignored unless connecting to a replica set via mongos.
@@ -353,8 +353,8 @@ class MongoClient(common.BaseObject):
         self.__auth_credentials = {}
 
         super(MongoClient, self).__init__(**options)
-        if self.slave_okay:
-            warnings.warn("slave_okay is deprecated. Please "
+        if self.subordinate_okay:
+            warnings.warn("subordinate_okay is deprecated. Please "
                           "use read_preference instead.", DeprecationWarning,
                           stacklevel=2)
 
@@ -534,7 +534,7 @@ class MongoClient(common.BaseObject):
     @property
     def is_primary(self):
         """If this instance is connected to a standalone, a replica set
-        primary, or the master of a master-slave set.
+        primary, or the main of a main-subordinate set.
 
         .. versionadded:: 2.3
         """
@@ -695,13 +695,13 @@ class MongoClient(common.BaseObject):
         :Parameters:
          - `node`: The (host, port) pair to try.
         """
-        # Call 'ismaster' directly so we can get a response time.
+        # Call 'ismain' directly so we can get a response time.
         connection_pool = self.__create_pool(node)
         sock_info = connection_pool.get_socket()
         try:
             response, res_time = self.__simple_command(sock_info,
                                                        'admin',
-                                                       {'ismaster': 1})
+                                                       {'ismain': 1})
         finally:
             connection_pool.maybe_return_socket(sock_info)
 
@@ -734,7 +734,7 @@ class MongoClient(common.BaseObject):
                 return self.__try_node(candidate)
 
             # Explain why we aren't using this connection.
-            raise AutoReconnect('%s:%d is not primary or master' % node)
+            raise AutoReconnect('%s:%d is not primary or main' % node)
 
         # Direct connection
         if member.is_arbiter and not self.__direct:
@@ -827,7 +827,7 @@ class MongoClient(common.BaseObject):
         Returns a Member and a set of nodes. Doesn't modify state.
 
         If only one host was supplied to __init__ see if we can connect
-        to it. Don't check if the host is a master/primary so we can make
+        to it. Don't check if the host is a main/primary so we can make
         a direct connection to read from a secondary or send commands to
         an arbiter.
 
@@ -1041,7 +1041,7 @@ class MongoClient(common.BaseObject):
         error_msg = result.get("err", "")
         if error_msg is None:
             return result
-        if error_msg.startswith("not master"):
+        if error_msg.startswith("not main"):
             self.disconnect()
             raise AutoReconnect(error_msg)
 
@@ -1100,7 +1100,7 @@ class MongoClient(common.BaseObject):
         member = self.__ensure_member()
         if check_primary and not with_last_error and not self.is_primary:
             # The write won't succeed, bail as if we'd done a getLastError
-            raise AutoReconnect("not master")
+            raise AutoReconnect("not main")
 
         sock_info = self.__socket(member)
         try:
@@ -1171,10 +1171,10 @@ class MongoClient(common.BaseObject):
             sock_info.close()
             raise
 
-    # we just ignore _must_use_master here: it's only relevant for
-    # MasterSlaveConnection instances.
+    # we just ignore _must_use_main here: it's only relevant for
+    # MainSubordinateConnection instances.
     def _send_message_with_response(self, message,
-                                    _must_use_master=False, **kwargs):
+                                    _must_use_main=False, **kwargs):
         """Send a message to Mongo and return the response.
 
         Sends the given message and returns the response.

--- a/pymongo-2.7/pymongo/mongo_replica_set_client.py
+++ b/pymongo-2.7/pymongo/mongo_replica_set_client.py
@@ -113,7 +113,7 @@ def _partition_node(node):
 # In __init__, MongoReplicaSetClient gets a list of potential members called
 # 'seeds' from its initial parameters, and calls refresh(). refresh() iterates
 # over the the seeds in arbitrary order looking for a member it can connect to.
-# Once it finds one, it calls 'ismaster' and sets self.__hosts to the list of
+# Once it finds one, it calls 'ismain' and sets self.__hosts to the list of
 # members in the response, and connects to the rest of the members. refresh()
 # sets the MongoReplicaSetClient's RSState. Finally, __init__ launches the
 # replica-set monitor.
@@ -136,7 +136,7 @@ class RSState(object):
 
         Stores Member instances for all members we're connected to, and a
         list of (host, port) pairs for all the hosts and arbiters listed
-        in the most recent ismaster response.
+        in the most recent ismain response.
 
         :Parameters:
           - `threadlocal`: Thread- or greenlet-local storage
@@ -211,7 +211,7 @@ class RSState(object):
 
     @property
     def arbiters(self):
-        """(host, port) pairs from the last ismaster response's arbiter list.
+        """(host, port) pairs from the last ismain response's arbiter list.
         """
         return self._arbiters
 
@@ -226,7 +226,7 @@ class RSState(object):
 
     @property
     def hosts(self):
-        """(host, port) pairs from the last ismaster response's host list."""
+        """(host, port) pairs from the last ismain response's host list."""
         return self._hosts
 
     @property
@@ -680,8 +680,8 @@ class MongoReplicaSetClient(common.BaseObject):
                                      "from PyPI.")
 
         super(MongoReplicaSetClient, self).__init__(**self.__opts)
-        if self.slave_okay:
-            warnings.warn("slave_okay is deprecated. Please "
+        if self.subordinate_okay:
+            warnings.warn("subordinate_okay is deprecated. Please "
                           "use read_preference instead.", DeprecationWarning,
                           stacklevel=2)
 
@@ -854,7 +854,7 @@ class MongoReplicaSetClient(common.BaseObject):
     def hosts(self):
         """All active and passive (priority 0) replica set
         members known to this client. This does not include
-        hidden or slaveDelay members, or arbiters.
+        hidden or subordinateDelay members, or arbiters.
 
         A sequence of (host, port) pairs.
         """
@@ -1025,8 +1025,8 @@ class MongoReplicaSetClient(common.BaseObject):
         helpers._check_command_response(response, None, msg)
         return response, end - start
 
-    def __is_master(self, host):
-        """Directly call ismaster.
+    def __is_main(self, host):
+        """Directly call ismain.
            Returns (response, connection_pool, ping_time in seconds).
         """
         connection_pool = self.pool_class(
@@ -1049,7 +1049,7 @@ class MongoReplicaSetClient(common.BaseObject):
         sock_info = connection_pool.get_socket()
         try:
             response, ping_time = self.__simple_command(
-                sock_info, 'admin', {'ismaster': 1}
+                sock_info, 'admin', {'ismain': 1}
             )
 
             connection_pool.maybe_return_socket(sock_info)
@@ -1136,11 +1136,11 @@ class MongoReplicaSetClient(common.BaseObject):
                 if member:
                     sock_info = self.__socket(member, force=True)
                     response, ping_time = self.__simple_command(
-                        sock_info, 'admin', {'ismaster': 1})
+                        sock_info, 'admin', {'ismain': 1})
                     member.pool.maybe_return_socket(sock_info)
                     new_member = member.clone_with(response, ping_time)
                 else:
-                    response, pool, ping_time = self.__is_master(node)
+                    response, pool, ping_time = self.__is_main(node)
                     new_member = Member(
                         node, pool, response, MovingAverage([ping_time]))
 
@@ -1170,7 +1170,7 @@ class MongoReplicaSetClient(common.BaseObject):
                 # but don't add seed list members.
                 if node in hosts:
                     members[node] = new_member
-                    if response['ismaster']:
+                    if response['ismain']:
                         writer = node
 
             except (ConnectionFailure, socket.error), why:
@@ -1197,7 +1197,7 @@ class MongoReplicaSetClient(common.BaseObject):
                 if member:
                     sock_info = self.__socket(member, force=True)
                     res, ping_time = self.__simple_command(
-                        sock_info, 'admin', {'ismaster': 1})
+                        sock_info, 'admin', {'ismain': 1})
 
                     if res.get('setName') != self.__name:
                         # Not a member of this set.
@@ -1206,7 +1206,7 @@ class MongoReplicaSetClient(common.BaseObject):
                     member.pool.maybe_return_socket(sock_info)
                     new_member = member.clone_with(res, ping_time)
                 else:
-                    res, connection_pool, ping_time = self.__is_master(host)
+                    res, connection_pool, ping_time = self.__is_main(host)
                     if res.get('setName') != self.__name:
                         # Not a member of this set.
                         continue
@@ -1221,7 +1221,7 @@ class MongoReplicaSetClient(common.BaseObject):
                     member.pool.discard_socket(sock_info)
                 continue
 
-            if res['ismaster']:
+            if res['ismain']:
                 writer = host
 
         if not members:
@@ -1243,9 +1243,9 @@ class MongoReplicaSetClient(common.BaseObject):
         # Get list of hosts in the RS config, including unreachable ones.
         # Prefer the primary's list, otherwise any member's list.
         if writer:
-            response = members[writer].ismaster_response
+            response = members[writer].ismain_response
         elif members:
-            response = members.values()[0].ismaster_response
+            response = members.values()[0].ismain_response
         else:
             response = {}
 
@@ -1411,7 +1411,7 @@ class MongoReplicaSetClient(common.BaseObject):
         error_msg = result.get("err", "")
         if error_msg is None:
             return result
-        if error_msg.startswith("not master"):
+        if error_msg.startswith("not main"):
             self.disconnect()
             raise AutoReconnect(error_msg)
 
@@ -1577,7 +1577,7 @@ class MongoReplicaSetClient(common.BaseObject):
             raise AutoReconnect("%s:%d: %s" % (host, port, why))
 
     def _send_message_with_response(self, msg, _connection_to_use=None,
-                                    _must_use_master=False, **kwargs):
+                                    _must_use_main=False, **kwargs):
         """Send a message to Mongo and return the response.
 
         Sends the given message and returns (host used, response).
@@ -1586,14 +1586,14 @@ class MongoReplicaSetClient(common.BaseObject):
           - `msg`: (request_id, data) pair making up the message to send
           - `_connection_to_use`: Optional (host, port) of member for message,
             used by Cursor for getMore and killCursors messages.
-          - `_must_use_master`: If True, send to primary.
+          - `_must_use_main`: If True, send to primary.
         """
         self._ensure_connected()
 
         rs_state = self.__get_rs_state()
         tag_sets = kwargs.get('tag_sets', [{}])
         mode = kwargs.get('read_preference', ReadPreference.PRIMARY)
-        if _must_use_master:
+        if _must_use_main:
             mode = ReadPreference.PRIMARY
             tag_sets = [{}]
 
@@ -1649,7 +1649,7 @@ class MongoReplicaSetClient(common.BaseObject):
                     pinned_member.host,
                     self.__try_read(pinned_member, msg, **kwargs))
             except AutoReconnect, why:
-                if _must_use_master or mode == ReadPreference.PRIMARY:
+                if _must_use_main or mode == ReadPreference.PRIMARY:
                     self.disconnect()
                     raise
                 else:

--- a/pymongo-2.7/pymongo/replica_set_connection.py
+++ b/pymongo-2.7/pymongo/replica_set_connection.py
@@ -160,7 +160,7 @@ class ReplicaSetConnection(MongoReplicaSetClient):
 
           | **Read preference options:**
 
-          - `slave_okay` or `slaveOk` (deprecated): Use `read_preference`
+          - `subordinate_okay` or `subordinateOk` (deprecated): Use `read_preference`
             instead.
           - `read_preference`: The read preference for this connection.
             See :class:`~pymongo.read_preferences.ReadPreference` for available

--- a/pymongo-2.7/test/high_availability/ha_tools.py
+++ b/pymongo-2.7/test/high_availability/ha_tools.py
@@ -344,15 +344,15 @@ def get_recovering():
 
 
 def get_passives():
-    return get_client().admin.command('ismaster').get('passives', [])
+    return get_client().admin.command('ismain').get('passives', [])
 
 
 def get_hosts():
-    return get_client().admin.command('ismaster').get('hosts', [])
+    return get_client().admin.command('ismain').get('hosts', [])
 
 
 def get_hidden_members():
-    # Both 'hidden' and 'slaveDelay'
+    # Both 'hidden' and 'subordinateDelay'
     secondaries = get_secondaries()
     readers = get_hosts() + get_passives()
     for member in readers:

--- a/pymongo-2.7/test/high_availability/test_ha.py
+++ b/pymongo-2.7/test/high_availability/test_ha.py
@@ -132,7 +132,7 @@ class TestDirectConnection(HATestCase):
             {'read_preference': SECONDARY},
             {'read_preference': SECONDARY_PREFERRED},
             {'read_preference': NEAREST},
-            {'slave_okay': True}
+            {'subordinate_okay': True}
         ]:
             client = MongoClient(primary_host,
                                  primary_port,
@@ -162,12 +162,12 @@ class TestDirectConnection(HATestCase):
                     AutoReconnect, client.pymongo_test.test.find_one)
 
             # Since an attempt at an acknowledged write to a secondary from a
-            # direct connection raises AutoReconnect('not master'), MongoClient
+            # direct connection raises AutoReconnect('not main'), MongoClient
             # should do the same for unacknowledged writes.
             try:
                 client.pymongo_test.test.insert({}, w=0)
             except AutoReconnect, e:
-                self.assertEqual('not master', e.args[0])
+                self.assertEqual('not main', e.args[0])
             else:
                 self.fail(
                     'Unacknowledged insert into secondary client %s should'
@@ -183,7 +183,7 @@ class TestDirectConnection(HATestCase):
             try:
                 client.pymongo_test.test.insert({}, w=0)
             except AutoReconnect, e:
-                self.assertEqual('not master', e.args[0])
+                self.assertEqual('not main', e.args[0])
             else:
                 self.fail(
                     'Unacknowledged insert into arbiter client %s should'
@@ -201,7 +201,7 @@ class TestPassiveAndHidden(HATestCase):
                    {'priority': 0},
                    {'arbiterOnly': True},
                    {'priority': 0, 'hidden': True},
-                   {'priority': 0, 'slaveDelay': 5}
+                   {'priority': 0, 'subordinateDelay': 5}
         ]
         res = ha_tools.start_replica_set(members)
         self.seed, self.name = res
@@ -228,7 +228,7 @@ class TestPassiveAndHidden(HATestCase):
 
 class TestMonitorRemovesRecoveringMember(HATestCase):
     # Members in STARTUP2 or RECOVERING states are shown in the primary's
-    # isMaster response, but aren't secondaries and shouldn't be read from.
+    # isMain response, but aren't secondaries and shouldn't be read from.
     # Verify that if a secondary goes into RECOVERING mode, the Monitor removes
     # it from the set of readers.
 
@@ -711,7 +711,7 @@ class TestReadPreference(HATestCase):
         self.assertTrue(MongoClient(
             unpartition_node(primary), use_greenlets=use_greenlets,
             read_preference=PRIMARY_PREFERRED
-        ).admin.command('ismaster')['ismaster'])
+        ).admin.command('ismain')['ismain'])
 
         sleep(2 * MONITOR_INTERVAL)
 
@@ -746,7 +746,7 @@ class TestReadPreference(HATestCase):
         self.assertTrue(MongoClient(
             unpartition_node(primary), use_greenlets=use_greenlets,
             read_preference=PRIMARY_PREFERRED
-        ).admin.command('ismaster')['ismaster'])
+        ).admin.command('ismain')['ismain'])
 
         #       PRIMARY
         assertReadFrom(primary, PRIMARY)

--- a/pymongo-2.7/test/test_auth.py
+++ b/pymongo-2.7/test/test_auth.py
@@ -91,7 +91,7 @@ class TestGSSAPI(unittest.TestCase):
         client = MongoClient(uri)
         self.assertTrue(client.database_names())
 
-        set_name = client.admin.command('ismaster').get('setName')
+        set_name = client.admin.command('ismain').get('setName')
         if set_name:
             client = MongoReplicaSetClient(GSSAPI_HOST,
                                            port=GSSAPI_PORT,
@@ -136,7 +136,7 @@ class TestGSSAPI(unittest.TestCase):
             thread.join()
             self.assertTrue(thread.success)
 
-        set_name = client.admin.command('ismaster').get('setName')
+        set_name = client.admin.command('ismain').get('setName')
         if set_name:
             preference = ReadPreference.SECONDARY
             client = MongoReplicaSetClient(GSSAPI_HOST,
@@ -177,7 +177,7 @@ class TestSASL(unittest.TestCase):
         client = MongoClient(uri)
         client.ldap.test.find_one()
 
-        set_name = client.admin.command('ismaster').get('setName')
+        set_name = client.admin.command('ismain').get('setName')
         if set_name:
             client = MongoReplicaSetClient(SASL_HOST,
                                            port=SASL_PORT,
@@ -235,7 +235,7 @@ class TestAuthURIOptions(unittest.TestCase):
             raise SkipTest("Auth with sharding requires MongoDB >= 2.0.0")
         if not server_started_with_auth(client):
             raise SkipTest('Authentication is not enabled on server')
-        response = client.admin.command('ismaster')
+        response = client.admin.command('ismain')
         self.set_name = str(response.get('setName', ''))
         client.admin.add_user('admin', 'pass', roles=['userAdminAnyDatabase',
                                                       'dbAdminAnyDatabase',

--- a/pymongo-2.7/test/test_bulk.py
+++ b/pymongo-2.7/test/test_bulk.py
@@ -890,9 +890,9 @@ class TestBulkWriteConcern(BulkTestBase):
     def setUp(self):
         super(TestBulkWriteConcern, self).setUp()
         client = get_client()
-        ismaster = client.test.command('ismaster')
-        self.is_repl = bool(ismaster.get('setName'))
-        self.w = len(ismaster.get("hosts", []))
+        ismain = client.test.command('ismain')
+        self.is_repl = bool(ismain.get('setName'))
+        self.w = len(ismain.get("hosts", []))
         self.coll = client.pymongo_test.test
         self.coll.remove()
 

--- a/pymongo-2.7/test/test_client.py
+++ b/pymongo-2.7/test/test_client.py
@@ -46,7 +46,7 @@ from test.utils import (assertRaisesExactly,
                         delay,
                         is_mongos,
                         remove_all_users,
-                        server_is_master_with_slave,
+                        server_is_main_with_subordinate,
                         server_started_with_auth,
                         TestRequestMixin,
                         _TestLazyConnectMixin,
@@ -221,8 +221,8 @@ class TestClient(unittest.TestCase, TestRequestMixin):
     def test_copy_db(self):
         c = MongoClient(host, port)
         # Due to SERVER-2329, databases may not disappear
-        # from a master in a master-slave pair.
-        if server_is_master_with_slave(c):
+        # from a main in a main-subordinate pair.
+        if server_is_main_with_subordinate(c):
             raise SkipTest("SERVER-2329")
         # We test copy twice; once starting in a request and once not. In
         # either case the copy should succeed (because it starts a request
@@ -317,9 +317,9 @@ class TestClient(unittest.TestCase, TestRequestMixin):
 
         self.assertEqual(c, MongoClient("mongodb://%s:%d" % (host, port)))
         self.assertTrue(MongoClient(
-            "mongodb://%s:%d" % (host, port), slave_okay=True).slave_okay)
+            "mongodb://%s:%d" % (host, port), subordinate_okay=True).subordinate_okay)
         self.assertTrue(MongoClient(
-            "mongodb://%s:%d/?slaveok=true;w=2" % (host, port)).slave_okay)
+            "mongodb://%s:%d/?subordinateok=true;w=2" % (host, port)).subordinate_okay)
 
     def test_get_default_database(self):
         c = MongoClient("mongodb://%s:%d/foo" % (host, port), _connect=False)
@@ -621,7 +621,7 @@ class TestClient(unittest.TestCase, TestRequestMixin):
             raise SkipTest('Requires server >= 2.0 to test with auth')
 
         res = c.admin.command('getCmdLineOpts')
-        if '--master' in res['argv'] and version.at_least(c, (2, 3, 0)):
+        if '--main' in res['argv'] and version.at_least(c, (2, 3, 0)):
             raise SkipTest('SERVER-7714')
 
         self.assertFalse(c.is_locked)
@@ -970,7 +970,7 @@ with client.start_request() as request:
 
     def test_replica_set(self):
         client = MongoClient(host, port)
-        name = client.pymongo_test.command('ismaster').get('setName')
+        name = client.pymongo_test.command('ismain').get('setName')
         if not name:
             raise SkipTest('Not connected to a replica set')
 

--- a/pymongo-2.7/test/test_collection.py
+++ b/pymongo-2.7/test/test_collection.py
@@ -68,9 +68,9 @@ class TestCollection(unittest.TestCase):
     def setUp(self):
         self.client = get_client()
         self.db = self.client.pymongo_test
-        ismaster = self.db.command('ismaster')
-        self.setname = ismaster.get('setName')
-        self.w = len(ismaster.get('hosts', [])) or 1
+        ismain = self.db.command('ismain')
+        self.setname = ismain.get('setName')
+        self.w = len(ismain.get('hosts', [])) or 1
 
     def tearDown(self):
         self.db.drop_collection("test_large_limit")
@@ -1308,9 +1308,9 @@ class TestCollection(unittest.TestCase):
         self.db.test.remove({"x": 1}, w=1, wtimeout=1)
         self.db.test.update({"x": 1}, {"y": 2}, w=1, wtimeout=1)
 
-        ismaster = self.client.admin.command("ismaster")
-        if ismaster.get("setName"):
-            w = len(ismaster["hosts"]) + 1
+        ismain = self.client.admin.command("ismain")
+        if ismain.get("setName"):
+            w = len(ismain["hosts"]) + 1
             self.assertRaises(WTimeoutError, self.db.test.save,
                               {"x": 1}, w=w, wtimeout=1)
             self.assertRaises(WTimeoutError, self.db.test.insert,

--- a/pymongo-2.7/test/test_common.py
+++ b/pymongo-2.7/test/test_common.py
@@ -66,16 +66,16 @@ class TestCommon(unittest.TestCase):
 
         # Connection tests
         c = Connection(pair)
-        self.assertFalse(c.slave_okay)
+        self.assertFalse(c.subordinate_okay)
         self.assertFalse(c.safe)
         self.assertEqual({}, c.get_lasterror_options())
         db = c.pymongo_test
         db.drop_collection("test")
-        self.assertFalse(db.slave_okay)
+        self.assertFalse(db.subordinate_okay)
         self.assertFalse(db.safe)
         self.assertEqual({}, db.get_lasterror_options())
         coll = db.test
-        self.assertFalse(coll.slave_okay)
+        self.assertFalse(coll.subordinate_okay)
         self.assertFalse(coll.safe)
         self.assertEqual({}, coll.get_lasterror_options())
 
@@ -92,22 +92,22 @@ class TestCommon(unittest.TestCase):
 
         coll = db.test
         cursor = coll.find()
-        self.assertFalse(cursor._Cursor__slave_okay)
-        cursor = coll.find(slave_okay=True)
-        self.assertTrue(cursor._Cursor__slave_okay)
+        self.assertFalse(cursor._Cursor__subordinate_okay)
+        cursor = coll.find(subordinate_okay=True)
+        self.assertTrue(cursor._Cursor__subordinate_okay)
 
         # MongoClient test
         c = MongoClient(pair)
-        self.assertFalse(c.slave_okay)
+        self.assertFalse(c.subordinate_okay)
         self.assertTrue(c.safe)
         self.assertEqual({}, c.get_lasterror_options())
         db = c.pymongo_test
         db.drop_collection("test")
-        self.assertFalse(db.slave_okay)
+        self.assertFalse(db.subordinate_okay)
         self.assertTrue(db.safe)
         self.assertEqual({}, db.get_lasterror_options())
         coll = db.test
-        self.assertFalse(coll.slave_okay)
+        self.assertFalse(coll.subordinate_okay)
         self.assertTrue(coll.safe)
         self.assertEqual({}, coll.get_lasterror_options())
 
@@ -124,31 +124,31 @@ class TestCommon(unittest.TestCase):
 
         coll = db.test
         cursor = coll.find()
-        self.assertFalse(cursor._Cursor__slave_okay)
-        cursor = coll.find(slave_okay=True)
-        self.assertTrue(cursor._Cursor__slave_okay)
+        self.assertFalse(cursor._Cursor__subordinate_okay)
+        cursor = coll.find(subordinate_okay=True)
+        self.assertTrue(cursor._Cursor__subordinate_okay)
 
         # Setting any safe operations overrides explicit safe
         self.assertTrue(MongoClient(host, port, wtimeout=1000, safe=False).safe)
 
-        c = MongoClient(pair, slaveok=True, w='majority',
+        c = MongoClient(pair, subordinateok=True, w='majority',
                         wtimeout=300, fsync=True, j=True)
-        self.assertTrue(c.slave_okay)
+        self.assertTrue(c.subordinate_okay)
         self.assertTrue(c.safe)
         d = {'w': 'majority', 'wtimeout': 300, 'fsync': True, 'j': True}
         self.assertEqual(d, c.get_lasterror_options())
         db = c.pymongo_test
-        self.assertTrue(db.slave_okay)
+        self.assertTrue(db.subordinate_okay)
         self.assertTrue(db.safe)
         self.assertEqual(d, db.get_lasterror_options())
         coll = db.test
-        self.assertTrue(coll.slave_okay)
+        self.assertTrue(coll.subordinate_okay)
         self.assertTrue(coll.safe)
         self.assertEqual(d, coll.get_lasterror_options())
         cursor = coll.find()
-        self.assertTrue(cursor._Cursor__slave_okay)
-        cursor = coll.find(slave_okay=False)
-        self.assertFalse(cursor._Cursor__slave_okay)
+        self.assertTrue(cursor._Cursor__subordinate_okay)
+        cursor = coll.find(subordinate_okay=False)
+        self.assertFalse(cursor._Cursor__subordinate_okay)
 
         c = MongoClient('mongodb://%s/?'
                        'w=2;wtimeoutMS=300;fsync=true;'
@@ -158,51 +158,51 @@ class TestCommon(unittest.TestCase):
         self.assertEqual(d, c.get_lasterror_options())
 
         c = MongoClient('mongodb://%s/?'
-                       'slaveok=true;w=1;wtimeout=300;'
+                       'subordinateok=true;w=1;wtimeout=300;'
                        'fsync=true;j=true' % (pair,))
-        self.assertTrue(c.slave_okay)
+        self.assertTrue(c.subordinate_okay)
         self.assertTrue(c.safe)
         d = {'w': 1, 'wtimeout': 300, 'fsync': True, 'j': True}
         self.assertEqual(d, c.get_lasterror_options())
         self.assertEqual(d, c.write_concern)
         db = c.pymongo_test
-        self.assertTrue(db.slave_okay)
+        self.assertTrue(db.subordinate_okay)
         self.assertTrue(db.safe)
         self.assertEqual(d, db.get_lasterror_options())
         self.assertEqual(d, db.write_concern)
         coll = db.test
-        self.assertTrue(coll.slave_okay)
+        self.assertTrue(coll.subordinate_okay)
         self.assertTrue(coll.safe)
         self.assertEqual(d, coll.get_lasterror_options())
         self.assertEqual(d, coll.write_concern)
         cursor = coll.find()
-        self.assertTrue(cursor._Cursor__slave_okay)
-        cursor = coll.find(slave_okay=False)
-        self.assertFalse(cursor._Cursor__slave_okay)
+        self.assertTrue(cursor._Cursor__subordinate_okay)
+        cursor = coll.find(subordinate_okay=False)
+        self.assertFalse(cursor._Cursor__subordinate_okay)
 
         c.unset_lasterror_options()
-        self.assertTrue(c.slave_okay)
+        self.assertTrue(c.subordinate_okay)
         self.assertTrue(c.safe)
         c.safe = False
         self.assertFalse(c.safe)
-        c.slave_okay = False
-        self.assertFalse(c.slave_okay)
+        c.subordinate_okay = False
+        self.assertFalse(c.subordinate_okay)
         self.assertEqual({}, c.get_lasterror_options())
         self.assertEqual({}, c.write_concern)
         db = c.pymongo_test
-        self.assertFalse(db.slave_okay)
+        self.assertFalse(db.subordinate_okay)
         self.assertFalse(db.safe)
         self.assertEqual({}, db.get_lasterror_options())
         self.assertEqual({}, db.write_concern)
         coll = db.test
-        self.assertFalse(coll.slave_okay)
+        self.assertFalse(coll.subordinate_okay)
         self.assertFalse(coll.safe)
         self.assertEqual({}, coll.get_lasterror_options())
         self.assertEqual({}, coll.write_concern)
         cursor = coll.find()
-        self.assertFalse(cursor._Cursor__slave_okay)
-        cursor = coll.find(slave_okay=True)
-        self.assertTrue(cursor._Cursor__slave_okay)
+        self.assertFalse(cursor._Cursor__subordinate_okay)
+        cursor = coll.find(subordinate_okay=True)
+        self.assertTrue(cursor._Cursor__subordinate_okay)
 
         coll.set_lasterror_options(fsync=True)
         self.assertEqual({'fsync': True}, coll.get_lasterror_options())
@@ -222,23 +222,23 @@ class TestCommon(unittest.TestCase):
         self.assertEqual({}, c.get_lasterror_options())
         self.assertEqual({}, c.write_concern)
         self.assertFalse(c.safe)
-        db.slave_okay = True
-        self.assertTrue(db.slave_okay)
-        self.assertFalse(c.slave_okay)
-        self.assertFalse(coll.slave_okay)
+        db.subordinate_okay = True
+        self.assertTrue(db.subordinate_okay)
+        self.assertFalse(c.subordinate_okay)
+        self.assertFalse(coll.subordinate_okay)
         cursor = coll.find()
-        self.assertFalse(cursor._Cursor__slave_okay)
+        self.assertFalse(cursor._Cursor__subordinate_okay)
         cursor = db.coll2.find()
-        self.assertTrue(cursor._Cursor__slave_okay)
-        cursor = db.coll2.find(slave_okay=False)
-        self.assertFalse(cursor._Cursor__slave_okay)
+        self.assertTrue(cursor._Cursor__subordinate_okay)
+        cursor = db.coll2.find(subordinate_okay=False)
+        self.assertFalse(cursor._Cursor__subordinate_okay)
 
         self.assertRaises(ConfigurationError, coll.set_lasterror_options, foo=20)
-        self.assertRaises(TypeError, coll._BaseObject__set_slave_okay, 20)
+        self.assertRaises(TypeError, coll._BaseObject__set_subordinate_okay, 20)
         self.assertRaises(TypeError, coll._BaseObject__set_safe, 20)
 
         coll.remove()
-        self.assertEqual(None, coll.find_one(slave_okay=True))
+        self.assertEqual(None, coll.find_one(subordinate_okay=True))
         coll.unset_lasterror_options()
         coll.set_lasterror_options(w=4, wtimeout=10)
         # Fails if we don't have 4 active nodes or we don't have replication...
@@ -470,9 +470,9 @@ class TestCommon(unittest.TestCase):
 
     def test_mongo_replica_set_client(self):
         c = MongoClient(pair)
-        ismaster = c.admin.command('ismaster')
-        if 'setName' in ismaster:
-            setname = str(ismaster.get('setName'))
+        ismain = c.admin.command('ismain')
+        if 'setName' in ismain:
+            setname = str(ismain.get('setName'))
         else:
             raise SkipTest("Not connected to a replica set.")
         m = MongoReplicaSetClient(pair, replicaSet=setname, w=0)

--- a/pymongo-2.7/test/test_cursor.py
+++ b/pymongo-2.7/test/test_cursor.py
@@ -624,7 +624,7 @@ class TestCursor(unittest.TestCase):
                                    snapshot=True,
                                    tailable=True,
                                    as_class=MyClass,
-                                   slave_okay=True,
+                                   subordinate_okay=True,
                                    await_data=True,
                                    partial=True,
                                    manipulate=False,
@@ -640,8 +640,8 @@ class TestCursor(unittest.TestCase):
         self.assertEqual(cursor._Cursor__snapshot, cursor2._Cursor__snapshot)
         self.assertEqual(type(cursor._Cursor__as_class),
                          type(cursor2._Cursor__as_class))
-        self.assertEqual(cursor._Cursor__slave_okay,
-                         cursor2._Cursor__slave_okay)
+        self.assertEqual(cursor._Cursor__subordinate_okay,
+                         cursor2._Cursor__subordinate_okay)
         self.assertEqual(cursor._Cursor__manipulate,
                          cursor2._Cursor__manipulate)
         self.assertEqual(cursor._Cursor__compile_re,
@@ -737,16 +737,16 @@ class TestCursor(unittest.TestCase):
         cursor.remove_option(32)
         self.assertEqual(2, cursor._Cursor__query_options())
 
-        # Slave OK
-        cursor = self.db.test.find(slave_okay=True)
+        # Subordinate OK
+        cursor = self.db.test.find(subordinate_okay=True)
         self.assertEqual(4, cursor._Cursor__query_options())
         cursor2 = self.db.test.find().add_option(4)
         self.assertEqual(cursor._Cursor__query_options(),
                          cursor2._Cursor__query_options())
-        self.assertTrue(cursor._Cursor__slave_okay)
+        self.assertTrue(cursor._Cursor__subordinate_okay)
         cursor.remove_option(4)
         self.assertEqual(0, cursor._Cursor__query_options())
-        self.assertFalse(cursor._Cursor__slave_okay)
+        self.assertFalse(cursor._Cursor__subordinate_okay)
 
         # Timeout
         cursor = self.db.test.find(timeout=False)

--- a/pymongo-2.7/test/test_gridfs.py
+++ b/pymongo-2.7/test/test_gridfs.py
@@ -417,7 +417,7 @@ class TestGridfsReplicaSet(TestReplicaSetClientBase):
 
         secondary_host, secondary_port = self.secondaries[0]
         for secondary_connection in [
-            MongoClient(secondary_host, secondary_port, slave_okay=True),
+            MongoClient(secondary_host, secondary_port, subordinate_okay=True),
             MongoClient(secondary_host, secondary_port,
                         read_preference=ReadPreference.SECONDARY),
         ]:

--- a/pymongo-2.7/test/test_legacy_connections.py
+++ b/pymongo-2.7/test/test_legacy_connections.py
@@ -36,7 +36,7 @@ class TestConnection(unittest.TestCase):
         c = Connection(host, port)
         self.assertTrue(c.auto_start_request)
         self.assertEqual(None, c.max_pool_size)
-        self.assertFalse(c.slave_okay)
+        self.assertFalse(c.subordinate_okay)
         self.assertFalse(c.safe)
         self.assertEqual({}, c.get_lasterror_options())
 
@@ -75,7 +75,7 @@ class TestReplicaSetConnection(TestReplicaSetClientBase):
         c = ReplicaSetConnection(pair, replicaSet=self.name)
         self.assertTrue(c.auto_start_request)
         self.assertEqual(None, c.max_pool_size)
-        self.assertFalse(c.slave_okay)
+        self.assertFalse(c.subordinate_okay)
         self.assertFalse(c.safe)
         self.assertEqual({}, c.get_lasterror_options())
 

--- a/pymongo-2.7/test/test_master_slave_connection.py
+++ b/pymongo-2.7/test/test_master_slave_connection.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test for master slave connections."""
+"""Test for main subordinate connections."""
 
 import datetime
 import os
@@ -33,33 +33,33 @@ from pymongo.errors import AutoReconnect
 from pymongo.database import Database
 from pymongo.mongo_client import MongoClient
 from pymongo.collection import Collection
-from pymongo.master_slave_connection import MasterSlaveConnection
+from pymongo.main_subordinate_connection import MainSubordinateConnection
 from test import host, port, host2, port2, host3, port3
 from test.utils import TestRequestMixin, get_pool
 
 
-class TestMasterSlaveConnection(unittest.TestCase, TestRequestMixin):
+class TestMainSubordinateConnection(unittest.TestCase, TestRequestMixin):
 
     def setUp(self):
-        self.master = MongoClient(host, port)
+        self.main = MongoClient(host, port)
 
-        self.slaves = []
+        self.subordinates = []
         try:
-            self.slaves.append(MongoClient(
+            self.subordinates.append(MongoClient(
                 host2, port2, read_preference=ReadPreference.SECONDARY))
         except ConnectionFailure:
             pass
 
         try:
-            self.slaves.append(MongoClient(
+            self.subordinates.append(MongoClient(
                 host3, port3, read_preference=ReadPreference.SECONDARY))
         except ConnectionFailure:
             pass
 
-        if not self.slaves:
-            raise SkipTest("Not connected to master-slave set")
+        if not self.subordinates:
+            raise SkipTest("Not connected to main-subordinate set")
 
-        self.client = MasterSlaveConnection(self.master, self.slaves)
+        self.client = MainSubordinateConnection(self.main, self.subordinates)
         self.db = self.client.pymongo_test
 
     def tearDown(self):
@@ -70,30 +70,30 @@ class TestMasterSlaveConnection(unittest.TestCase, TestRequestMixin):
             # that make this fail
             pass
 
-        self.master = self.slaves = self.db = self.client = None
-        super(TestMasterSlaveConnection, self).tearDown()
+        self.main = self.subordinates = self.db = self.client = None
+        super(TestMainSubordinateConnection, self).tearDown()
 
     def test_types(self):
-        self.assertRaises(TypeError, MasterSlaveConnection, 1)
-        self.assertRaises(TypeError, MasterSlaveConnection, self.master, 1)
-        self.assertRaises(TypeError, MasterSlaveConnection, self.master, [1])
+        self.assertRaises(TypeError, MainSubordinateConnection, 1)
+        self.assertRaises(TypeError, MainSubordinateConnection, self.main, 1)
+        self.assertRaises(TypeError, MainSubordinateConnection, self.main, [1])
 
     def test_use_greenlets(self):
         self.assertFalse(self.client.use_greenlets)
 
         if thread_util.have_gevent:
-            master = MongoClient(host, port, use_greenlets=True)
-            slaves = [
-                MongoClient(slave.host, slave.port, use_greenlets=True)
-                for slave in self.slaves]
+            main = MongoClient(host, port, use_greenlets=True)
+            subordinates = [
+                MongoClient(subordinate.host, subordinate.port, use_greenlets=True)
+                for subordinate in self.subordinates]
 
             self.assertTrue(
-                MasterSlaveConnection(master, slaves).use_greenlets)
+                MainSubordinateConnection(main, subordinates).use_greenlets)
 
     def test_repr(self):
         self.assertEqual(repr(self.client),
-                         "MasterSlaveConnection(%r, %r)" %
-                         (self.master, self.slaves))
+                         "MainSubordinateConnection(%r, %r)" %
+                         (self.main, self.subordinates))
 
     def test_disconnect(self):
         class MongoClient(object):
@@ -103,27 +103,27 @@ class TestMasterSlaveConnection(unittest.TestCase, TestRequestMixin):
             def disconnect(self):
                 self._disconnects += 1
 
-        self.client._MasterSlaveConnection__master = MongoClient()
-        self.client._MasterSlaveConnection__slaves = [MongoClient(),
+        self.client._MainSubordinateConnection__main = MongoClient()
+        self.client._MainSubordinateConnection__subordinates = [MongoClient(),
                                                       MongoClient()]
 
         self.client.disconnect()
         self.assertEqual(1,
-            self.client._MasterSlaveConnection__master._disconnects)
+            self.client._MainSubordinateConnection__main._disconnects)
         self.assertEqual(1,
-            self.client._MasterSlaveConnection__slaves[0]._disconnects)
+            self.client._MainSubordinateConnection__subordinates[0]._disconnects)
         self.assertEqual(1,
-            self.client._MasterSlaveConnection__slaves[1]._disconnects)
+            self.client._MainSubordinateConnection__subordinates[1]._disconnects)
 
-    def test_continue_until_slave_works(self):
-        class Slave(object):
+    def test_continue_until_subordinate_works(self):
+        class Subordinate(object):
             calls = 0
 
             def __init__(self, fail):
                 self._fail = fail
 
             def _send_message_with_response(self, *args, **kwargs):
-                Slave.calls += 1
+                Subordinate.calls += 1
                 if self._fail:
                     raise AutoReconnect()
                 return (None, 'sent')
@@ -132,8 +132,8 @@ class TestMasterSlaveConnection(unittest.TestCase, TestRequestMixin):
             last_idx = -1
 
             def __init__(self):
-                self._items = [Slave(True), Slave(True),
-                               Slave(False), Slave(True)]
+                self._items = [Subordinate(True), Subordinate(True),
+                               Subordinate(False), Subordinate(True)]
 
             def __len__(self):
                 return len(self._items)
@@ -142,30 +142,30 @@ class TestMasterSlaveConnection(unittest.TestCase, TestRequestMixin):
                 NotRandomList.last_idx = idx
                 return self._items.pop(0)
 
-        self.client._MasterSlaveConnection__slaves = NotRandomList()
+        self.client._MainSubordinateConnection__subordinates = NotRandomList()
 
         response = self.client._send_message_with_response('message')
         self.assertEqual((NotRandomList.last_idx, 'sent'), response)
         self.assertNotEqual(-1, NotRandomList.last_idx)
-        self.assertEqual(3, Slave.calls)
+        self.assertEqual(3, Subordinate.calls)
 
-    def test_raise_autoreconnect_if_all_slaves_fail(self):
-        class Slave(object):
+    def test_raise_autoreconnect_if_all_subordinates_fail(self):
+        class Subordinate(object):
             calls = 0
 
             def __init__(self, fail):
                 self._fail = fail
 
             def _send_message_with_response(self, *args, **kwargs):
-                Slave.calls += 1
+                Subordinate.calls += 1
                 if self._fail:
                     raise AutoReconnect()
                 return 'sent'
 
         class NotRandomList(object):
             def __init__(self):
-                self._items = [Slave(True), Slave(True),
-                               Slave(True), Slave(True)]
+                self._items = [Subordinate(True), Subordinate(True),
+                               Subordinate(True), Subordinate(True)]
 
             def __len__(self):
                 return len(self._items)
@@ -173,11 +173,11 @@ class TestMasterSlaveConnection(unittest.TestCase, TestRequestMixin):
             def __getitem__(self, idx):
                 return self._items.pop(0)
 
-        self.client._MasterSlaveConnection__slaves = NotRandomList()
+        self.client._MainSubordinateConnection__subordinates = NotRandomList()
 
         self.assertRaises(AutoReconnect,
             self.client._send_message_with_response, 'message')
-        self.assertEqual(4, Slave.calls)
+        self.assertEqual(4, Subordinate.calls)
 
     def test_get_db(self):
 
@@ -250,13 +250,13 @@ class TestMasterSlaveConnection(unittest.TestCase, TestRequestMixin):
 
         def assertRequest(in_request):
             self.assertEqual(in_request, client.in_request())
-            self.assertEqual(in_request, client.master.in_request())
+            self.assertEqual(in_request, client.main.in_request())
 
-        # MasterSlaveConnection is special, alas - it has no auto_start_request
+        # MainSubordinateConnection is special, alas - it has no auto_start_request
         # and it begins *not* in a request. When it's in a request, it sends
         # all queries to primary.
         self.assertFalse(client.in_request())
-        self.assertFalse(client.master.in_request())
+        self.assertFalse(client.main.in_request())
 
         # Start and end request
         client.start_request()
@@ -275,9 +275,9 @@ class TestMasterSlaveConnection(unittest.TestCase, TestRequestMixin):
     def test_request_threads(self):
         client = self.client
 
-        # In a request, all ops go through master
-        pool = get_pool(client.master)
-        client.master.end_request()
+        # In a request, all ops go through main
+        pool = get_pool(client.main)
+        client.main.end_request()
         self.assertNotInRequestAndDifferentSock(client, pool)
 
         started_request, ended_request = threading.Event(), threading.Event()
@@ -313,7 +313,7 @@ class TestMasterSlaveConnection(unittest.TestCase, TestRequestMixin):
         self.assertNotInRequestAndDifferentSock(client, pool)
         self.assertTrue(thread_done[0], "Thread didn't complete")
 
-    # This was failing because commands were being sent to the slaves
+    # This was failing because commands were being sent to the subordinates
     def test_create_collection(self):
         self.client.pymongo_test.test.drop()
 
@@ -333,7 +333,7 @@ class TestMasterSlaveConnection(unittest.TestCase, TestRequestMixin):
 
     # NOTE this test is non-deterministic, but I expect
     # some failures unless the db is pulling instantaneously...
-    def test_insert_find_one_with_slaves(self):
+    def test_insert_find_one_with_subordinates(self):
         count = 0
         for i in range(100):
             self.db.test.remove({})
@@ -346,7 +346,7 @@ class TestMasterSlaveConnection(unittest.TestCase, TestRequestMixin):
         self.assertTrue(count)
 
     # NOTE this test is non-deterministic, but hopefully we pause long enough
-    # for the slaves to pull...
+    # for the subordinates to pull...
     def test_insert_find_one_with_pause(self):
         count = 0
 
@@ -363,14 +363,14 @@ class TestMasterSlaveConnection(unittest.TestCase, TestRequestMixin):
 
     def test_kill_cursor_explicit(self):
         c = self.client
-        c.slave_okay = True
+        c.subordinate_okay = True
         db = c.pymongo_test
 
-        test = db.master_slave_test_kill_cursor_explicit
+        test = db.main_subordinate_test_kill_cursor_explicit
         test.drop()
 
         for i in range(20):
-            test.insert({"i": i}, w=1 + len(self.slaves))
+            test.insert({"i": i}, w=1 + len(self.subordinates))
 
         st = time.time()
         while time.time() - st < 120:
@@ -389,7 +389,7 @@ class TestMasterSlaveConnection(unittest.TestCase, TestRequestMixin):
         self.assertNotEqual(
             cursor._Cursor__connection_id,
             -1,
-            "Expected cursor connected to a slave, not master")
+            "Expected cursor connected to a subordinate, not main")
 
         self.assertTrue(cursor.next())
         self.assertNotEqual(0, cursor.cursor_id)
@@ -413,45 +413,45 @@ class TestMasterSlaveConnection(unittest.TestCase, TestRequestMixin):
 
     def test_base_object(self):
         c = self.client
-        self.assertFalse(c.slave_okay)
+        self.assertFalse(c.subordinate_okay)
         self.assertTrue(bool(c.read_preference))
         self.assertTrue(c.safe)
         self.assertEqual({}, c.get_lasterror_options())
         db = c.pymongo_test
-        self.assertFalse(db.slave_okay)
+        self.assertFalse(db.subordinate_okay)
         self.assertTrue(bool(c.read_preference))
         self.assertTrue(db.safe)
         self.assertEqual({}, db.get_lasterror_options())
         coll = db.test
         coll.drop()
-        self.assertFalse(coll.slave_okay)
+        self.assertFalse(coll.subordinate_okay)
         self.assertTrue(bool(c.read_preference))
         self.assertTrue(coll.safe)
         self.assertEqual({}, coll.get_lasterror_options())
         cursor = coll.find()
-        self.assertFalse(cursor._Cursor__slave_okay)
+        self.assertFalse(cursor._Cursor__subordinate_okay)
         self.assertTrue(bool(cursor._Cursor__read_preference))
 
-        w = 1 + len(self.slaves)
+        w = 1 + len(self.subordinates)
         wtimeout=10000 # Wait 10 seconds for replication to complete
         c.set_lasterror_options(w=w, wtimeout=wtimeout)
-        self.assertFalse(c.slave_okay)
+        self.assertFalse(c.subordinate_okay)
         self.assertTrue(bool(c.read_preference))
         self.assertTrue(c.safe)
         self.assertEqual({'w': w, 'wtimeout': wtimeout}, c.get_lasterror_options())
         db = c.pymongo_test
-        self.assertFalse(db.slave_okay)
+        self.assertFalse(db.subordinate_okay)
         self.assertTrue(bool(c.read_preference))
         self.assertTrue(db.safe)
         self.assertEqual({'w': w, 'wtimeout': wtimeout}, db.get_lasterror_options())
         coll = db.test
-        self.assertFalse(coll.slave_okay)
+        self.assertFalse(coll.subordinate_okay)
         self.assertTrue(bool(c.read_preference))
         self.assertTrue(coll.safe)
         self.assertEqual({'w': w, 'wtimeout': wtimeout},
                          coll.get_lasterror_options())
         cursor = coll.find()
-        self.assertFalse(cursor._Cursor__slave_okay)
+        self.assertFalse(cursor._Cursor__subordinate_okay)
         self.assertTrue(bool(cursor._Cursor__read_preference))
 
         coll.insert({'foo': 'bar'})
@@ -462,15 +462,15 @@ class TestMasterSlaveConnection(unittest.TestCase, TestRequestMixin):
 
         c.safe = False
         c.unset_lasterror_options()
-        self.assertFalse(self.client.slave_okay)
+        self.assertFalse(self.client.subordinate_okay)
         self.assertTrue(bool(self.client.read_preference))
         self.assertFalse(self.client.safe)
         self.assertEqual({}, self.client.get_lasterror_options())
 
     def test_document_class(self):
-        c = MasterSlaveConnection(self.master, self.slaves)
+        c = MainSubordinateConnection(self.main, self.subordinates)
         db = c.pymongo_test
-        w = 1 + len(self.slaves)
+        w = 1 + len(self.subordinates)
         db.test.insert({"x": 1}, w=w)
 
         self.assertEqual(dict, c.document_class)
@@ -483,7 +483,7 @@ class TestMasterSlaveConnection(unittest.TestCase, TestRequestMixin):
         self.assertTrue(isinstance(db.test.find_one(), SON))
         self.assertFalse(isinstance(db.test.find_one(as_class=dict), SON))
 
-        c = MasterSlaveConnection(self.master, self.slaves, document_class=SON)
+        c = MainSubordinateConnection(self.main, self.subordinates, document_class=SON)
         db = c.pymongo_test
 
         self.assertEqual(SON, c.document_class)
@@ -498,20 +498,20 @@ class TestMasterSlaveConnection(unittest.TestCase, TestRequestMixin):
 
     def test_tz_aware(self):
         dt = datetime.datetime.utcnow()
-        client = MasterSlaveConnection(self.master, self.slaves)
+        client = MainSubordinateConnection(self.main, self.subordinates)
         self.assertEqual(False, client.tz_aware)
         db = client.pymongo_test
-        w = 1 + len(self.slaves)
+        w = 1 + len(self.subordinates)
         db.tztest.insert({'dt': dt}, w=w)
         self.assertEqual(None, db.tztest.find_one()['dt'].tzinfo)
 
-        client = MasterSlaveConnection(self.master, self.slaves, tz_aware=True)
+        client = MainSubordinateConnection(self.main, self.subordinates, tz_aware=True)
         self.assertEqual(True, client.tz_aware)
         db = client.pymongo_test
         db.tztest.insert({'dt': dt}, w=w)
         self.assertEqual(utc, db.tztest.find_one()['dt'].tzinfo)
 
-        client = MasterSlaveConnection(self.master, self.slaves, tz_aware=False)
+        client = MainSubordinateConnection(self.main, self.subordinates, tz_aware=False)
         self.assertEqual(False, client.tz_aware)
         db = client.pymongo_test
         db.tztest.insert({'dt': dt}, w=w)

--- a/pymongo-2.7/test/test_read_preferences.py
+++ b/pymongo-2.7/test/test_read_preferences.py
@@ -515,7 +515,7 @@ class TestMongosConnection(unittest.TestCase):
         SECONDARY = ReadPreference.SECONDARY
         SECONDARY_PREFERRED = ReadPreference.SECONDARY_PREFERRED
         NEAREST = ReadPreference.NEAREST
-        SLAVE_OKAY = _QUERY_OPTIONS['slave_okay']
+        SLAVE_OKAY = _QUERY_OPTIONS['subordinate_okay']
 
         # Test non-PRIMARY modes which can be combined with tags
         for kwarg, value, mongos_mode in (
@@ -523,21 +523,21 @@ class TestMongosConnection(unittest.TestCase):
             ('read_preference', SECONDARY, 'secondary'),
             ('read_preference', SECONDARY_PREFERRED, 'secondaryPreferred'),
             ('read_preference', NEAREST, 'nearest'),
-            ('slave_okay', True, 'secondaryPreferred'),
-            ('slave_okay', False, 'primary')
+            ('subordinate_okay', True, 'secondaryPreferred'),
+            ('subordinate_okay', False, 'primary')
         ):
             for tag_sets in (
                 None, [{}]
             ):
                 # Create a client e.g. with read_preference=NEAREST or
-                # slave_okay=True
+                # subordinate_okay=True
                 c = get_client(tag_sets=tag_sets, **{kwarg: value})
 
                 self.assertEqual(is_mongos, c.is_mongos)
                 cursor = c.pymongo_test.test.find()
                 if is_mongos:
                     # We don't set $readPreference for SECONDARY_PREFERRED
-                    # unless tags are in use. slaveOkay has the same effect.
+                    # unless tags are in use. subordinateOkay has the same effect.
                     if mongos_mode == 'secondaryPreferred':
                         self.assertEqual(
                             None,
@@ -570,8 +570,8 @@ class TestMongosConnection(unittest.TestCase):
                 [{'dc': 'la'}, {'dc': 'sf'}],
                 [{'dc': 'la'}, {'dc': 'sf'}, {}],
             ):
-                if kwarg == 'slave_okay':
-                    # Can't use tags with slave_okay True or False, need a
+                if kwarg == 'subordinate_okay':
+                    # Can't use tags with subordinate_okay True or False, need a
                     # real read preference
                     self.assertRaises(
                         ConfigurationError,

--- a/pymongo-2.7/test/test_replica_set_client.py
+++ b/pymongo-2.7/test/test_replica_set_client.py
@@ -60,7 +60,7 @@ class TestReplicaSetClientAgainstStandalone(unittest.TestCase):
     """
     def setUp(self):
         client = MongoClient(pair)
-        response = client.admin.command('ismaster')
+        response = client.admin.command('ismain')
         if 'setName' in response:
             raise SkipTest("Connected to a replica set, not a standalone mongod")
 
@@ -73,7 +73,7 @@ class TestReplicaSetClientAgainstStandalone(unittest.TestCase):
 class TestReplicaSetClientBase(unittest.TestCase):
     def setUp(self):
         client = MongoClient(pair)
-        response = client.admin.command('ismaster')
+        response = client.admin.command('ismain')
         if 'setName' in response:
             self.name = str(response['setName'])
             self.w = len(response['hosts'])
@@ -242,7 +242,7 @@ class TestReplicaSetClient(TestReplicaSetClientBase, TestRequestMixin):
             self.assertEqual(obj.read_preference, ReadPreference.PRIMARY)
             self.assertEqual(obj.tag_sets, [{}])
             self.assertEqual(obj.secondary_acceptable_latency_ms, 15)
-            self.assertEqual(obj.slave_okay, False)
+            self.assertEqual(obj.subordinate_okay, False)
             self.assertEqual(obj.write_concern, {})
 
         cursor = c.pymongo_test.test.find()
@@ -250,13 +250,13 @@ class TestReplicaSetClient(TestReplicaSetClientBase, TestRequestMixin):
             ReadPreference.PRIMARY, cursor._Cursor__read_preference)
         self.assertEqual([{}], cursor._Cursor__tag_sets)
         self.assertEqual(15, cursor._Cursor__secondary_acceptable_latency_ms)
-        self.assertEqual(False, cursor._Cursor__slave_okay)
+        self.assertEqual(False, cursor._Cursor__subordinate_okay)
         c.close()
 
         tag_sets = [{'dc': 'la', 'rack': '2'}, {'foo': 'bar'}]
         c = MongoReplicaSetClient(pair, replicaSet=self.name, max_pool_size=25,
                                  document_class=SON, tz_aware=True,
-                                 slaveOk=False,
+                                 subordinateOk=False,
                                  read_preference=ReadPreference.SECONDARY,
                                  tag_sets=copy.deepcopy(tag_sets),
                                  secondary_acceptable_latency_ms=77)
@@ -272,7 +272,7 @@ class TestReplicaSetClient(TestReplicaSetClientBase, TestRequestMixin):
             self.assertEqual(obj.read_preference, ReadPreference.SECONDARY)
             self.assertEqual(obj.tag_sets, tag_sets)
             self.assertEqual(obj.secondary_acceptable_latency_ms, 77)
-            self.assertEqual(obj.slave_okay, False)
+            self.assertEqual(obj.subordinate_okay, False)
             self.assertEqual(obj.safe, True)
 
         cursor = c.pymongo_test.test.find()
@@ -280,7 +280,7 @@ class TestReplicaSetClient(TestReplicaSetClientBase, TestRequestMixin):
             ReadPreference.SECONDARY, cursor._Cursor__read_preference)
         self.assertEqual(tag_sets, cursor._Cursor__tag_sets)
         self.assertEqual(77, cursor._Cursor__secondary_acceptable_latency_ms)
-        self.assertEqual(False, cursor._Cursor__slave_okay)
+        self.assertEqual(False, cursor._Cursor__subordinate_okay)
 
         cursor = c.pymongo_test.test.find(
             read_preference=ReadPreference.NEAREST,
@@ -291,7 +291,7 @@ class TestReplicaSetClient(TestReplicaSetClientBase, TestRequestMixin):
             ReadPreference.NEAREST, cursor._Cursor__read_preference)
         self.assertEqual([{'dc':'ny'}, {}], cursor._Cursor__tag_sets)
         self.assertEqual(123, cursor._Cursor__secondary_acceptable_latency_ms)
-        self.assertEqual(False, cursor._Cursor__slave_okay)
+        self.assertEqual(False, cursor._Cursor__subordinate_okay)
 
         if version.at_least(c, (1, 7, 4)):
             self.assertEqual(c.max_bson_size, 16777216)
@@ -487,7 +487,7 @@ class TestReplicaSetClient(TestReplicaSetClientBase, TestRequestMixin):
                 c.copy_database("pymongo_test", "pymongo_test1",
                                 username="mike", password="password")
                 self.assertTrue("pymongo_test1" in c.database_names())
-                res = c.pymongo_test1.test.find_one(_must_use_master=True)
+                res = c.pymongo_test1.test.find_one(_must_use_main=True)
                 self.assertEqual("bar", res["foo"])
             finally:
                 # Cleanup
@@ -1207,7 +1207,7 @@ class TestReplicaSetClientInternalIPs(unittest.TestCase):
             standalones=[],
             members=['a:1'],
             mongoses=[],
-            ismaster_hosts=['internal-ip:27017'],
+            ismain_hosts=['internal-ip:27017'],
             host='a:1',
             replicaSet='rs')
 

--- a/pymongo-2.7/test/test_replica_set_reconfig.py
+++ b/pymongo-2.7/test/test_replica_set_reconfig.py
@@ -96,7 +96,7 @@ class TestSecondaryRemoved(unittest.TestCase):
         self.assertTrue(('c', 3) in c.secondaries)
 
         # C is removed.
-        c.mock_ismaster_hosts.remove('c:3')
+        c.mock_ismain_hosts.remove('c:3')
         c.refresh()
 
         self.assertEqual(('a', 1), c.primary)
@@ -139,7 +139,7 @@ class TestSecondaryAdded(unittest.TestCase):
 
         # C is added.
         c.mock_members.append('c:3')
-        c.mock_ismaster_hosts.append('c:3')
+        c.mock_ismain_hosts.append('c:3')
 
         c.disconnect()
         c.db.collection.find_one()
@@ -161,7 +161,7 @@ class TestSecondaryAdded(unittest.TestCase):
 
         # C is added.
         c.mock_members.append('c:3')
-        c.mock_ismaster_hosts.append('c:3')
+        c.mock_ismain_hosts.append('c:3')
         c.refresh()
 
         self.assertEqual(('a', 1), c.primary)

--- a/pymongo-2.7/test/test_ssl.py
+++ b/pymongo-2.7/test/test_ssl.py
@@ -217,7 +217,7 @@ class TestSSL(unittest.TestCase):
             raise SkipTest("No simple mongod available over SSL")
 
         client = MongoClient(host, port, ssl=True)
-        response = client.admin.command('ismaster')
+        response = client.admin.command('ismain')
         if 'setName' in response:
             client = MongoReplicaSetClient(pair,
                                            replicaSet=response['setName'],
@@ -243,7 +243,7 @@ class TestSSL(unittest.TestCase):
             raise SkipTest("No mongod available over SSL with certs")
 
         client = MongoClient(host, port, ssl=True, ssl_certfile=CLIENT_PEM)
-        response = client.admin.command('ismaster')
+        response = client.admin.command('ismain')
         if 'setName' in response:
             client = MongoReplicaSetClient(pair,
                                            replicaSet=response['setName'],
@@ -269,7 +269,7 @@ class TestSSL(unittest.TestCase):
             raise SkipTest("No mongod available over SSL with certs")
 
         client = MongoClient(host, port, ssl_certfile=CLIENT_PEM)
-        response = client.admin.command('ismaster')
+        response = client.admin.command('ismain')
         if 'setName' in response:
             client = MongoReplicaSetClient(pair,
                                            replicaSet=response['setName'],
@@ -303,7 +303,7 @@ class TestSSL(unittest.TestCase):
                              ssl_certfile=CLIENT_PEM,
                              ssl_cert_reqs=ssl.CERT_REQUIRED,
                              ssl_ca_certs=CA_PEM)
-        response = client.admin.command('ismaster')
+        response = client.admin.command('ismain')
         if 'setName' in response:
             if response['primary'].split(":")[0] != 'server':
                 raise SkipTest("No hosts in the replicaset for 'server'. "
@@ -345,7 +345,7 @@ class TestSSL(unittest.TestCase):
                              ssl_cert_reqs=ssl.CERT_OPTIONAL,
                              ssl_ca_certs=CA_PEM)
 
-        response = client.admin.command('ismaster')
+        response = client.admin.command('ismain')
         if 'setName' in response:
             if response['primary'].split(":")[0] != 'server':
                 raise SkipTest("No hosts in the replicaset for 'server'. "
@@ -376,7 +376,7 @@ class TestSSL(unittest.TestCase):
             raise SkipTest("No mongod available over SSL with certs")
 
         client = MongoClient(host, port, ssl=True, ssl_certfile=CLIENT_PEM)
-        response = client.admin.command('ismaster')
+        response = client.admin.command('ismain')
 
         try:
             MongoClient(pair,

--- a/pymongo-2.7/test/test_uri_parser.py
+++ b/pymongo-2.7/test/test_uri_parser.py
@@ -198,15 +198,15 @@ class TestURI(unittest.TestCase):
 
         res = copy.deepcopy(orig)
         res['nodelist'] = [("::1", 27017)]
-        res['options'] = {'slaveok': True}
-        self.assertEqual(res, parse_uri("mongodb://[::1]:27017/?slaveOk=true"))
+        res['options'] = {'subordinateok': True}
+        self.assertEqual(res, parse_uri("mongodb://[::1]:27017/?subordinateOk=true"))
 
         res = copy.deepcopy(orig)
         res['nodelist'] = [("2001:0db8:85a3:0000:0000:8a2e:0370:7334", 27017)]
-        res['options'] = {'slaveok': True}
+        res['options'] = {'subordinateok': True}
         self.assertEqual(res, parse_uri(
                               "mongodb://[2001:0db8:85a3:0000:0000"
-                              ":8a2e:0370:7334]:27017/?slaveOk=true"))
+                              ":8a2e:0370:7334]:27017/?subordinateOk=true"))
 
         res = copy.deepcopy(orig)
         res['nodelist'] = [("/tmp/mongodb-27017.sock", None)]
@@ -274,10 +274,10 @@ class TestURI(unittest.TestCase):
         res = copy.deepcopy(orig)
         res.update({'username': 'fred', 'password': 'foobar'})
         res.update({'database': 'test', 'collection': 'yield_historical.in'})
-        res['options'] = {'slaveok': True}
+        res['options'] = {'subordinateok': True}
         self.assertEqual(res,
                          parse_uri("mongodb://fred:foobar@localhost/"
-                                   "test.yield_historical.in?slaveok=true"))
+                                   "test.yield_historical.in?subordinateok=true"))
 
         res = copy.deepcopy(orig)
         res['options'] = {'readpreference': ReadPreference.SECONDARY}

--- a/pymongo-2.7/test/utils.py
+++ b/pymongo-2.7/test/utils.py
@@ -113,11 +113,11 @@ def server_started_with_nojournal(client):
     return server_started_with_option(client, '--nojournal', 'nojournal')
 
 
-def server_is_master_with_slave(client):
+def server_is_main_with_subordinate(client):
     command_line = get_command_line(client)
     if 'parsed' in command_line:
-        return command_line['parsed'].get('master', False)
-    return '--master' in command_line['argv']
+        return command_line['parsed'].get('main', False)
+    return '--main' in command_line['argv']
 
 def drop_collections(db):
     for coll in db.collection_names():
@@ -138,7 +138,7 @@ def joinall(threads):
         assert not t.isAlive(), "Thread %s hung" % t
 
 def is_mongos(client):
-    res = client.admin.command('ismaster')
+    res = client.admin.command('ismain')
     return res.get('msg', '') == 'isdbgrid'
 
 def enable_text_search(client):
@@ -578,9 +578,9 @@ class _TestLazyConnectMixin(object):
 
         # Make the client connect, so that it sets its max_bson_size and
         # max_message_size attributes.
-        ismaster = c.db.command('ismaster')
-        self.assertEqual(ismaster['maxBsonObjectSize'], c.max_bson_size)
-        if 'maxMessageSizeBytes' in ismaster:
+        ismain = c.db.command('ismain')
+        self.assertEqual(ismain['maxBsonObjectSize'], c.max_bson_size)
+        if 'maxMessageSizeBytes' in ismain:
             self.assertEqual(
-                ismaster['maxMessageSizeBytes'],
+                ismain['maxMessageSizeBytes'],
                 c.max_message_size)

--- a/python-dateutil-1.5/dateutil/parser.py
+++ b/python-dateutil-1.5/dateutil/parser.py
@@ -31,7 +31,7 @@ __all__ = ["parse", "parserinfo"]
 # http://www.cl.cam.ac.uk/~mgk25/iso-time.html
 # http://www.iso.ch/iso/en/prods-services/popstds/datesandtime.html
 # http://www.w3.org/TR/NOTE-datetime
-# http://ringmaster.arc.nasa.gov/tools/time_formats.html
+# http://ringmain.arc.nasa.gov/tools/time_formats.html
 # http://search.cpan.org/author/MUIR/Time-modules-2003.0211/lib/Time/ParseDate.pm
 # http://stein.cshl.org/jade/distrib/docs/java.text.SimpleDateFormat.html
 

--- a/requests-v1.1.0-9/docs/conf.py
+++ b/requests-v1.1.0-9/docs/conf.py
@@ -38,8 +38,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Requests'


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.